### PR TITLE
Run GitHub actions on all branches and pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,6 @@
 name: Continuous Integration Workflow
 
-on:
-    push:
-        branches: ['main']
-    pull_request:
-        branches: ['main']
+on: [push, pull_request]
 
 jobs:
     install:


### PR DESCRIPTION
Otherwise Renovate update branches will not execute GitHub actions and therefore not be able to automatically merge because of our branch protection rules.