### PR TITLE
Extends fake-client to inspect operation options

### DIFF
--- a/source/zod-graphql-fake-client/fake-client.test.ts
+++ b/source/zod-graphql-fake-client/fake-client.test.ts
@@ -17,6 +17,17 @@ test('throws when inspecting a query that doesn’t exist', () => {
     }
 });
 
+test('throws when inspecting a operation options that don’t exist', () => {
+    const client = createFakeGraphqlClient();
+
+    try {
+        client.inspectFirstOperationOptions();
+        assert.fail('Expected inspectFirstOperationOptions() to throw but it did not');
+    } catch (error: unknown) {
+        assert.strictEqual((error as Error).message, 'No operationOption at index 0 recorded');
+    }
+});
+
 test('query() returns the default result when no result is configured', async () => {
     const client = createFakeGraphqlClient();
 
@@ -107,4 +118,42 @@ test('inspectFirstOperationPayload() returns the mutation payload of the first m
     const payload = client.inspectFirstOperationPayload();
 
     assert.deepStrictEqual(payload, { operationName: 'foo', query: 'mutation foo { foo }', variables: {} });
+});
+
+test('inspectFirstOperationOptions() returns the operation options of the first query', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, {
+        operationName: 'foo',
+        headers: { foo: 'bar' },
+        timeout: 42,
+        variables: {}
+    });
+    const options = client.inspectFirstOperationOptions();
+
+    assert.deepStrictEqual(options, {
+        operationName: 'foo',
+        headers: { foo: 'bar' },
+        timeout: 42,
+        variables: {}
+    });
+});
+
+test('inspectFirstOperationOptions() returns the operation options of the first mutation', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.mutateOrThrow(simpleQuery, {
+        operationName: 'foo',
+        headers: { foo: 'bar' },
+        timeout: 42,
+        variables: {}
+    });
+    const options = client.inspectFirstOperationOptions();
+
+    assert.deepStrictEqual(options, {
+        operationName: 'foo',
+        headers: { foo: 'bar' },
+        timeout: 42,
+        variables: {}
+    });
 });

--- a/source/zod-graphql-fake-client/fake-client.ts
+++ b/source/zod-graphql-fake-client/fake-client.ts
@@ -13,6 +13,8 @@ import { buildGraphqlMutation, buildGraphqlQuery } from '../zod-graphql-query-bu
 export type FakeGraphqlClient = GraphqlClient & {
     readonly inspectOperationPayload: (index: number) => GraphqlOverHttpOperationRequestPayload;
     readonly inspectFirstOperationPayload: () => GraphqlOverHttpOperationRequestPayload;
+    readonly inspectOperationOptions: (index: number) => OperationOptions;
+    readonly inspectFirstOperationOptions: () => OperationOptions;
 };
 
 type FakeSuccessData = {
@@ -33,6 +35,7 @@ type FakeClientOptions = {
 export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): FakeGraphqlClient {
     const { results = [] } = clientOptions;
     const operationPayloads: GraphqlOverHttpOperationRequestPayload[] = [];
+    const operationOptions: OperationOptions[] = [];
     const defaultResult: FakeResult = { data: {} };
 
     async function collectOperation<Schema extends QuerySchema>(
@@ -61,6 +64,7 @@ export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): 
             query: serializedQuery,
             variables: variableValues
         });
+        operationOptions.push(options);
 
         if (result.error !== undefined) {
             return { success: false, errorDetails: result.error };
@@ -91,6 +95,15 @@ export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): 
         return payload;
     }
 
+    function inspectOperationOptions(index: number): OperationOptions {
+        const operationOption = operationOptions[index];
+        if (operationOption === undefined) {
+            throw new Error(`No operationOption at index ${index} recorded`);
+        }
+
+        return operationOption;
+    }
+
     return {
         query,
 
@@ -118,6 +131,10 @@ export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): 
 
         inspectFirstOperationPayload() {
             return inspectOperationPayload(0);
+        },
+        inspectOperationOptions,
+        inspectFirstOperationOptions() {
+            return inspectOperationOptions(0);
         }
     };
 }


### PR DESCRIPTION
I as a user of the `zod-graphql-client` want to make sure that my endpoints are called with the correct http-headers. This PR extends the fake-client in the same manner as we already inspect the payload but for all operation-options incl. headers