### PR TITLE
Deduplicate boundary formatters, operation payload, and variable-set merges

### DIFF
--- a/source/zod-error-formatter/issue-specific/boundary-issue.ts
+++ b/source/zod-error-formatter/issue-specific/boundary-issue.ts
@@ -1,0 +1,63 @@
+import type { $ZodIssueTooBig, $ZodIssueTooSmall } from 'zod/v4/core';
+
+type BoundaryIssue = $ZodIssueTooBig | $ZodIssueTooSmall;
+
+export type BoundaryPhrases = {
+    readonly collectionInclusive: string;
+    readonly collectionNonInclusive: string;
+    readonly numericInclusive: string;
+    readonly numericNonInclusive: string;
+    readonly dateInclusive: string;
+    readonly dateNonInclusive: string;
+};
+
+const collectionTypes = new Set(['string', 'array', 'set']);
+const numericTypes = new Set(['bigint', 'number']);
+
+function inclusivePredicate(issue: BoundaryIssue, inclusiveVariant: string, nonInclusiveVariant: string): string {
+    if (issue.inclusive === true) {
+        return inclusiveVariant;
+    }
+    return nonInclusiveVariant;
+}
+
+function formatPredicate(issue: BoundaryIssue, phrases: BoundaryPhrases): string {
+    if (issue.exact === true) {
+        return 'exactly';
+    }
+
+    if (collectionTypes.has(issue.origin)) {
+        return inclusivePredicate(issue, phrases.collectionInclusive, phrases.collectionNonInclusive);
+    }
+
+    if (numericTypes.has(issue.origin)) {
+        return inclusivePredicate(issue, phrases.numericInclusive, phrases.numericNonInclusive);
+    }
+
+    return inclusivePredicate(issue, phrases.dateInclusive, phrases.dateNonInclusive);
+}
+
+function formatCollectionBoundary(issue: BoundaryIssue, boundary: bigint | number): string {
+    const singularSuffix = issue.origin === 'string' ? 'character' : 'element';
+    const suffix = boundary === 1 ? singularSuffix : `${singularSuffix}s`;
+
+    return `${boundary} ${suffix}`;
+}
+
+export function formatBoundaryIssue(
+    issue: BoundaryIssue,
+    boundary: bigint | number,
+    phrases: BoundaryPhrases
+): string {
+    const predicate = formatPredicate(issue, phrases);
+
+    if (collectionTypes.has(issue.origin)) {
+        return `${issue.origin} must contain ${predicate} ${formatCollectionBoundary(issue, boundary)}`;
+    }
+
+    if (numericTypes.has(issue.origin)) {
+        return `${issue.origin} must be ${predicate} ${boundary}`;
+    }
+
+    return `${issue.origin} must be ${predicate} ${new Date(Number(boundary)).toUTCString()}`;
+}

--- a/source/zod-error-formatter/issue-specific/too-big.ts
+++ b/source/zod-error-formatter/issue-specific/too-big.ts
@@ -1,69 +1,15 @@
 import type { $ZodIssueTooBig } from 'zod/v4/core';
+import { type BoundaryPhrases, formatBoundaryIssue } from './boundary-issue.js';
 
-const collectionTypes = new Set(['string', 'array', 'set']);
-const numericTypes = new Set(['bigint', 'number']);
-
-function formatInclusivePredicate(
-    issue: $ZodIssueTooBig,
-    inclusiveVariant: string,
-    nonInclusiveVariant: string
-): string {
-    if (issue.inclusive === true) {
-        return inclusiveVariant;
-    }
-    return nonInclusiveVariant;
-}
-
-function formatPredicate(issue: $ZodIssueTooBig): string {
-    if (issue.exact === true) {
-        return 'exactly';
-    }
-
-    if (collectionTypes.has(issue.origin)) {
-        return formatInclusivePredicate(issue, 'at most', 'less than');
-    }
-
-    if (numericTypes.has(issue.origin)) {
-        return formatInclusivePredicate(issue, 'less than or equal to', 'less than');
-    }
-
-    return formatInclusivePredicate(issue, 'smaller than or equal to', 'smaller than');
-}
-
-function formatCollectionBoundary(issue: $ZodIssueTooBig): string {
-    const singularSuffix = issue.origin === 'string' ? 'character' : 'element';
-    const suffix = issue.maximum === 1 ? singularSuffix : `${singularSuffix}s`;
-
-    return `${issue.maximum} ${suffix}`;
-}
-
-function formatCollection(issue: $ZodIssueTooBig): string {
-    const predicate = formatPredicate(issue);
-    const boundary = formatCollectionBoundary(issue);
-
-    return `${issue.origin} must contain ${predicate} ${boundary}`;
-}
-
-function formatNumeric(issue: $ZodIssueTooBig): string {
-    const predicate = formatPredicate(issue);
-
-    return `${issue.origin} must be ${predicate} ${issue.maximum}`;
-}
-
-function formatDate(issue: $ZodIssueTooBig): string {
-    const predicate = formatPredicate(issue);
-
-    return `${issue.origin} must be ${predicate} ${new Date(Number(issue.maximum)).toUTCString()}`;
-}
+const phrases: BoundaryPhrases = {
+    collectionInclusive: 'at most',
+    collectionNonInclusive: 'less than',
+    numericInclusive: 'less than or equal to',
+    numericNonInclusive: 'less than',
+    dateInclusive: 'smaller than or equal to',
+    dateNonInclusive: 'smaller than'
+};
 
 export function formatTooBigIssueMessage(issue: $ZodIssueTooBig): string {
-    if (collectionTypes.has(issue.origin)) {
-        return formatCollection(issue);
-    }
-
-    if (numericTypes.has(issue.origin)) {
-        return formatNumeric(issue);
-    }
-
-    return formatDate(issue);
+    return formatBoundaryIssue(issue, issue.maximum, phrases);
 }

--- a/source/zod-error-formatter/issue-specific/too-small.ts
+++ b/source/zod-error-formatter/issue-specific/too-small.ts
@@ -1,65 +1,15 @@
 import type { $ZodIssueTooSmall } from 'zod/v4/core';
+import { type BoundaryPhrases, formatBoundaryIssue } from './boundary-issue.js';
 
-const collectionTypes = new Set(['string', 'array', 'set']);
-const numericTypes = new Set(['bigint', 'number']);
-
-function formatInclusivePredicate(
-    issue: $ZodIssueTooSmall,
-    inclusiveVariant: string,
-    nonInclusiveVariant: string
-): string {
-    if (issue.inclusive === true) {
-        return inclusiveVariant;
-    }
-    return nonInclusiveVariant;
-}
-
-function formatPredicate(issue: $ZodIssueTooSmall): string {
-    if (issue.exact === true) {
-        return 'exactly';
-    }
-
-    if (collectionTypes.has(issue.origin)) {
-        return formatInclusivePredicate(issue, 'at least', 'more than');
-    }
-
-    return formatInclusivePredicate(issue, 'greater than or equal to', 'greater than');
-}
-
-function formatCollectionBoundary(issue: $ZodIssueTooSmall): string {
-    const singularSuffix = issue.origin === 'string' ? 'character' : 'element';
-    const suffix = issue.minimum === 1 ? singularSuffix : `${singularSuffix}s`;
-
-    return `${issue.minimum} ${suffix}`;
-}
-
-function formatCollection(issue: $ZodIssueTooSmall): string {
-    const predicate = formatPredicate(issue);
-    const boundary = formatCollectionBoundary(issue);
-
-    return `${issue.origin} must contain ${predicate} ${boundary}`;
-}
-
-function formatNumeric(issue: $ZodIssueTooSmall): string {
-    const predicate = formatPredicate(issue);
-
-    return `${issue.origin} must be ${predicate} ${issue.minimum}`;
-}
-
-function formatDate(issue: $ZodIssueTooSmall): string {
-    const predicate = formatPredicate(issue);
-
-    return `${issue.origin} must be ${predicate} ${new Date(Number(issue.minimum)).toUTCString()}`;
-}
+const phrases: BoundaryPhrases = {
+    collectionInclusive: 'at least',
+    collectionNonInclusive: 'more than',
+    numericInclusive: 'greater than or equal to',
+    numericNonInclusive: 'greater than',
+    dateInclusive: 'greater than or equal to',
+    dateNonInclusive: 'greater than'
+};
 
 export function formatTooSmallIssueMessage(issue: $ZodIssueTooSmall): string {
-    if (collectionTypes.has(issue.origin)) {
-        return formatCollection(issue);
-    }
-
-    if (numericTypes.has(issue.origin)) {
-        return formatNumeric(issue);
-    }
-
-    return formatDate(issue);
+    return formatBoundaryIssue(issue, issue.minimum, phrases);
 }

--- a/source/zod-graphql-client/client.ts
+++ b/source/zod-graphql-client/client.ts
@@ -1,20 +1,13 @@
 import { type KyInstance, type Options as KyRequestOptions, TimeoutError } from 'ky';
 import type { output as TypeOf } from 'zod/v4/core';
 import { safeParse } from '../zod-error-formatter/formatter.js';
-import { buildGraphqlMutation, buildGraphqlQuery, type QuerySchema } from '../zod-graphql-query-builder/entry-point.js';
+import type { QuerySchema } from '../zod-graphql-query-builder/entry-point.js';
 import { parseGraphqlResponse } from './graphql-response.js';
 import { GraphqlOperationError } from './operation-error.js';
+import { buildOperationPayload, type OperationOptions } from './operation-payload.js';
 import type { OperationFailureResult, OperationResult, OperationResultForType } from './operation-result.js';
-import { extractVariableDefinitions, extractVariableValues, type Variables } from './variables.js';
 
-type OperationType = 'mutation' | 'query';
-
-export type OperationOptions = {
-    operationName?: string;
-    timeout?: number;
-    headers?: Record<string, string | undefined>;
-    variables?: Variables;
-};
+export type { OperationOptions } from './operation-payload.js';
 
 export type ClientOptions = {
     endpoint: string;
@@ -50,6 +43,13 @@ export type CreateClientDependencies = {
 const defaultRequestTimeout = 10_000;
 const successResponseStatusCode = 200;
 
+export function extractDataOrThrow<Data>(result: OperationResultForType<Data>): Data {
+    if (result.success) {
+        return result.data;
+    }
+    throw new GraphqlOperationError(result.errorDetails);
+}
+
 function mapUnknownNetworkErrorToFailureResult(error: unknown, timeout: number): OperationFailureResult {
     if (error instanceof TimeoutError) {
         return {
@@ -78,12 +78,6 @@ function mapUnknownNetworkErrorToFailureResult(error: unknown, timeout: number):
     };
 }
 
-export type GraphqlOverHttpOperationRequestPayload = {
-    query: string;
-    variables: Record<string, unknown>;
-    operationName?: string | undefined;
-};
-
 export function createClientFactory(dependencies: CreateClientDependencies): CreateClientFn {
     const { ky } = dependencies;
 
@@ -98,32 +92,6 @@ export function createClientFactory(dependencies: CreateClientDependencies): Cre
                 timeout,
                 throwHttpErrors: false,
                 retry: 0
-            };
-        }
-
-        function prepareRequestPayload(
-            schema: QuerySchema,
-            operationType: OperationType,
-            options: OperationOptions
-        ): GraphqlOverHttpOperationRequestPayload {
-            const { variables = {} } = options;
-            const variableDefinitions = extractVariableDefinitions(variables);
-            const variableValues = extractVariableValues(variables);
-
-            const serializedQuery = operationType === 'query' ?
-                buildGraphqlQuery(schema, {
-                    operationName: options.operationName,
-                    variableDefinitions
-                }) :
-                buildGraphqlMutation(schema, {
-                    operationName: options.operationName,
-                    variableDefinitions
-                });
-
-            return {
-                query: serializedQuery,
-                variables: variableValues,
-                operationName: options.operationName
             };
         }
 
@@ -201,7 +169,7 @@ export function createClientFactory(dependencies: CreateClientDependencies): Cre
             operationType: 'mutation' | 'query',
             options: OperationOptions = {}
         ): Promise<OperationResult<Schema>> {
-            const payload = prepareRequestPayload(schema, operationType, options);
+            const payload = buildOperationPayload(schema, operationType, options);
 
             const serverResponseParseResult = await fetchGraphqlEndpoint(options, payload);
 
@@ -235,23 +203,13 @@ export function createClientFactory(dependencies: CreateClientDependencies): Cre
             query,
 
             async queryOrThrow(schema, options) {
-                const result = await query(schema, options);
-                if (result.success) {
-                    return result.data;
-                }
-
-                throw new GraphqlOperationError(result.errorDetails);
+                return extractDataOrThrow(await query(schema, options));
             },
 
             mutate,
 
             async mutateOrThrow(schema, options) {
-                const result = await mutate(schema, options);
-                if (result.success) {
-                    return result.data;
-                }
-
-                throw new GraphqlOperationError(result.errorDetails);
+                return extractDataOrThrow(await mutate(schema, options));
             }
         };
     };

--- a/source/zod-graphql-client/entry-point.ts
+++ b/source/zod-graphql-client/entry-point.ts
@@ -20,7 +20,8 @@ export {
     graphqlFieldOptions,
     variablePlaceholder
 } from '../zod-graphql-query-builder/entry-point.js';
-export type { GraphqlClient, GraphqlOverHttpOperationRequestPayload } from './client.js';
+export type { GraphqlClient } from './client.js';
 export type { OperationErrorDetails } from './operation-error.js';
 export { GraphqlOperationError } from './operation-error.js';
+export type { GraphqlOverHttpOperationRequestPayload } from './operation-payload.js';
 export type { OperationResult } from './operation-result.js';

--- a/source/zod-graphql-client/operation-payload.ts
+++ b/source/zod-graphql-client/operation-payload.ts
@@ -1,0 +1,43 @@
+import { buildGraphqlMutation, buildGraphqlQuery, type QuerySchema } from '../zod-graphql-query-builder/entry-point.js';
+import { extractVariableDefinitions, extractVariableValues, type Variables } from './variables.js';
+
+export type OperationType = 'mutation' | 'query';
+
+export type OperationOptions = {
+    operationName?: string;
+    timeout?: number;
+    headers?: Record<string, string | undefined>;
+    variables?: Variables;
+};
+
+export type GraphqlOverHttpOperationRequestPayload = {
+    query: string;
+    variables: Record<string, unknown>;
+    operationName?: string | undefined;
+};
+
+export function buildOperationPayload(
+    schema: QuerySchema,
+    operationType: OperationType,
+    options: OperationOptions
+): GraphqlOverHttpOperationRequestPayload {
+    const { variables = {} } = options;
+    const variableDefinitions = extractVariableDefinitions(variables);
+    const variableValues = extractVariableValues(variables);
+
+    const serializedQuery = operationType === 'query' ?
+        buildGraphqlQuery(schema, {
+            operationName: options.operationName,
+            variableDefinitions
+        }) :
+        buildGraphqlMutation(schema, {
+            operationName: options.operationName,
+            variableDefinitions
+        });
+
+    return {
+        query: serializedQuery,
+        variables: variableValues,
+        operationName: options.operationName
+    };
+}

--- a/source/zod-graphql-fake-client/fake-client.ts
+++ b/source/zod-graphql-fake-client/fake-client.ts
@@ -1,14 +1,16 @@
 import type { output as TypeOf } from 'zod/v4/core';
-import type { GraphqlOverHttpOperationRequestPayload, OperationOptions } from '../zod-graphql-client/client.js';
-import {
-    type GraphqlClient,
-    GraphqlOperationError,
-    type OperationErrorDetails,
-    type OperationResult,
-    type QuerySchema
+import { extractDataOrThrow } from '../zod-graphql-client/client.js';
+import type {
+    GraphqlClient,
+    OperationErrorDetails,
+    OperationResult,
+    QuerySchema
 } from '../zod-graphql-client/entry-point.js';
-import { extractVariableDefinitions, extractVariableValues } from '../zod-graphql-client/variables.js';
-import { buildGraphqlMutation, buildGraphqlQuery } from '../zod-graphql-query-builder/entry-point.js';
+import {
+    buildOperationPayload,
+    type GraphqlOverHttpOperationRequestPayload,
+    type OperationOptions
+} from '../zod-graphql-client/operation-payload.js';
 
 export type FakeGraphqlClient = GraphqlClient & {
     readonly inspectOperationPayload: (index: number) => GraphqlOverHttpOperationRequestPayload;
@@ -43,27 +45,10 @@ export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): 
         type: 'mutation' | 'query',
         options: OperationOptions = {}
     ): Promise<OperationResult<Schema>> {
-        const { variables = {} } = options;
-        const variableDefinitions = extractVariableDefinitions(variables);
-        const variableValues = extractVariableValues(variables);
-
-        const serializedQuery = type === 'query' ?
-            buildGraphqlQuery(schema, {
-                operationName: options.operationName,
-                variableDefinitions
-            }) :
-            buildGraphqlMutation(schema, {
-                operationName: options.operationName,
-                variableDefinitions
-            });
-
+        const payload = buildOperationPayload(schema, type, options);
         const result = results[operationPayloads.length] ?? defaultResult;
 
-        operationPayloads.push({
-            operationName: options.operationName,
-            query: serializedQuery,
-            variables: variableValues
-        });
+        operationPayloads.push(payload);
         operationOptions.push(options);
 
         if (result.error !== undefined) {
@@ -108,23 +93,13 @@ export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): 
         query,
 
         async queryOrThrow(schema, options) {
-            const result = await query(schema, options);
-            if (result.success) {
-                return result.data;
-            }
-
-            throw new GraphqlOperationError(result.errorDetails);
+            return extractDataOrThrow(await query(schema, options));
         },
 
         mutate,
 
         async mutateOrThrow(schema, options) {
-            const result = await mutate(schema, options);
-            if (result.success) {
-                return result.data;
-            }
-
-            throw new GraphqlOperationError(result.errorDetails);
+            return extractDataOrThrow(await mutate(schema, options));
         },
 
         inspectOperationPayload,

--- a/source/zod-graphql-query-builder/builder.ts
+++ b/source/zod-graphql-query-builder/builder.ts
@@ -28,6 +28,7 @@ import {
 } from './query-schema.js';
 import { normalizeParameterList } from './values/parameter-list.js';
 import type { GraphqlValue, NormalizedGraphqlValue } from './values/value.js';
+import { mergeVariables } from './values/variable-set.js';
 import { ensureValidVariableCorrelations } from './variable-correlations.js';
 import { serializeVariableDefinitions, type VariableDefinitions } from './variable-definition.js';
 
@@ -153,7 +154,7 @@ export function createQueryBuilder(): QueryBuilder {
         for (const [fieldName, fieldSchema] of entries) {
             // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursion
             const serializedField = serializeFieldSchema(fieldName, fieldSchema);
-            referencedVariables = new Set([...referencedVariables, ...serializedField.referencedVariables]);
+            referencedVariables = mergeVariables(referencedVariables, serializedField.referencedVariables);
             serializedEntries.push(serializedField.serializedValue);
         }
 
@@ -181,7 +182,7 @@ export function createQueryBuilder(): QueryBuilder {
                 );
             }
             const serializedFragment = serializeObjectSchema(fragmentSchema);
-            referencedVariables = new Set([...referencedVariables, ...serializedFragment.referencedVariables]);
+            referencedVariables = mergeVariables(referencedVariables, serializedFragment.referencedVariables);
             serializedFragments.push(`... on ${fragmentName.toString()}${serializedFragment.serializedValue}`);
         }
         return {
@@ -196,10 +197,7 @@ export function createQueryBuilder(): QueryBuilder {
     ): NormalizedGraphqlValue {
         return {
             serializedValue: `${fieldSelector.serializedValue}${fieldBody.serializedValue}`,
-            referencedVariables: new Set([
-                ...fieldSelector.referencedVariables,
-                ...fieldBody.referencedVariables
-            ])
+            referencedVariables: mergeVariables(fieldSelector.referencedVariables, fieldBody.referencedVariables)
         };
     }
 

--- a/source/zod-graphql-query-builder/values/parameter-list.ts
+++ b/source/zod-graphql-query-builder/values/parameter-list.ts
@@ -1,5 +1,6 @@
 import { isValidGraphqlName } from './name.js';
 import { type GraphqlValue, type NormalizedGraphqlValue, normalizeGraphqlValue } from './value.js';
+import { mergeVariables } from './variable-set.js';
 
 export function normalizeParameterList(parameters: Record<string, GraphqlValue>): NormalizedGraphqlValue {
     let referencedVariables = new Set<string>();
@@ -12,7 +13,7 @@ export function normalizeParameterList(parameters: Record<string, GraphqlValue>)
 
         const normalizedParameterValue = normalizeGraphqlValue(parameterValue);
         serializedParameters.push(`${parameterName}: ${normalizedParameterValue.serializedValue}`);
-        referencedVariables = new Set([...referencedVariables, ...normalizedParameterValue.referencedVariables]);
+        referencedVariables = mergeVariables(referencedVariables, normalizedParameterValue.referencedVariables);
     }
 
     return {

--- a/source/zod-graphql-query-builder/values/value.ts
+++ b/source/zod-graphql-query-builder/values/value.ts
@@ -2,6 +2,7 @@ import { type GraphqlEnumValue, isEnumValue } from './enum.js';
 import { isValidGraphqlName } from './name.js';
 import { isRecord } from './record.js';
 import { type GraphqlVariablePlaceholder, isVariablePlaceholder } from './variable-placeholder.js';
+import { mergeVariables } from './variable-set.js';
 
 type GraphqlObjectValue = { [Key: string]: GraphqlValue; };
 
@@ -43,7 +44,7 @@ function normalizeObjectValue(value: GraphqlObjectValue): NormalizedGraphqlValue
         // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
         const normalizedFieldValue = normalizeGraphqlValue(fieldValue);
         serializedFields.push(`${fieldName}: ${normalizedFieldValue.serializedValue}`);
-        referencedVariables = new Set([...referencedVariables, ...normalizedFieldValue.referencedVariables]);
+        referencedVariables = mergeVariables(referencedVariables, normalizedFieldValue.referencedVariables);
     }
 
     return {
@@ -60,7 +61,7 @@ function normalizeListValue(value: GraphqlValue[]): NormalizedGraphqlValue {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
         const normalizedItem = normalizeGraphqlValue(item);
         serializedItems.push(normalizedItem.serializedValue);
-        referencedVariables = new Set([...referencedVariables, ...normalizedItem.referencedVariables]);
+        referencedVariables = mergeVariables(referencedVariables, normalizedItem.referencedVariables);
     }
 
     return {

--- a/source/zod-graphql-query-builder/values/variable-set.ts
+++ b/source/zod-graphql-query-builder/values/variable-set.ts
@@ -1,0 +1,3 @@
+export function mergeVariables(first: ReadonlySet<string>, second: ReadonlySet<string>): Set<string> {
+    return new Set([...first, ...second]);
+}


### PR DESCRIPTION
Extract a shared boundary-issue formatter so too-big and too-small reduce to phrase tables. Lift buildOperationPayload out of the client closure and reuse it from the fake client. Replace inline Set unions in the query-builder with a mergeVariables helper.