### PR TITLE
Configure continuous integration for merge queue without duplicate pull request runs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,10 @@
 ---
 name: Continuous Integration Workflow
 
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
+    merge_group:
 
 jobs:
     install:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,6 +3,7 @@ name: Continuous Integration Workflow
 
 on:
     push:
+        branches: [main]
     pull_request:
     merge_group:
 


### PR DESCRIPTION
Enable GitHub merge queue support in continuous integration while avoiding duplicate workflow runs for pull request changes.