### PR TITLE
Add matcher-based operation lookup to the fake GraphQL client

### DIFF
--- a/source/zod-graphql-fake-client/fake-client.test.ts
+++ b/source/zod-graphql-fake-client/fake-client.test.ts
@@ -157,3 +157,143 @@ test('inspectFirstOperationOptions() returns the operation options of the first 
         variables: {}
     });
 });
+
+test('findOperation() returns undefined when no operation was recorded', () => {
+    const client = createFakeGraphqlClient();
+
+    const found = client.findOperation({ operationName: 'foo' });
+
+    assert.strictEqual(found, undefined);
+});
+
+test('findOperation() returns the first operation matching by operationName', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'first' });
+    await client.queryOrThrow(simpleQuery, { operationName: 'second' });
+
+    const found = client.findOperation({ operationName: 'second' });
+
+    assert.strictEqual(found?.options.operationName, 'second');
+});
+
+test('findOperation() returns the first operation matching by type', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'a-query' });
+    await client.mutateOrThrow(simpleQuery, { operationName: 'a-mutation' });
+
+    const found = client.findOperation({ type: 'mutation' });
+
+    assert.strictEqual(found?.options.operationName, 'a-mutation');
+});
+
+test('findOperation() returns the first operation matching by schema identity', async () => {
+    const otherQuery = z.object({ bar: z.string() }).strict();
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'a' });
+    await client.queryOrThrow(otherQuery, { operationName: 'b' });
+
+    const found = client.findOperation({ schema: otherQuery });
+
+    assert.strictEqual(found?.options.operationName, 'b');
+});
+
+test('findOperation() ANDs all fields of the matcher object', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'foo' });
+    await client.mutateOrThrow(simpleQuery, { operationName: 'foo' });
+
+    const found = client.findOperation({ operationName: 'foo', type: 'mutation' });
+
+    assert.strictEqual(found?.type, 'mutation');
+});
+
+test('findOperation() returns undefined when no operation matches', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'foo' });
+
+    const found = client.findOperation({ operationName: 'bar' });
+
+    assert.strictEqual(found, undefined);
+});
+
+test('findOperation() accepts a predicate function', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'foo', headers: { 'x-tenant': 'a' } });
+    await client.queryOrThrow(simpleQuery, { operationName: 'bar', headers: { 'x-tenant': 'b' } });
+
+    const found = client.findOperation((recorded) => {
+        return recorded.options.headers?.['x-tenant'] === 'b';
+    });
+
+    assert.strictEqual(found?.options.operationName, 'bar');
+});
+
+test('findAllOperations() returns every operation matching the matcher', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'a' });
+    await client.mutateOrThrow(simpleQuery, { operationName: 'b' });
+    await client.queryOrThrow(simpleQuery, { operationName: 'c' });
+
+    const found = client.findAllOperations({ type: 'query' });
+
+    assert.deepStrictEqual(
+        found.map((recorded) => {
+            return recorded.options.operationName;
+        }),
+        ['a', 'c']
+    );
+});
+
+test('findAllOperations() returns an empty array when nothing matches', () => {
+    const client = createFakeGraphqlClient();
+
+    const found = client.findAllOperations({ operationName: 'nope' });
+
+    assert.deepStrictEqual(found, []);
+});
+
+test('findOperationOrThrow() returns the matching operation', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'foo' });
+
+    const found = client.findOperationOrThrow({ operationName: 'foo' });
+
+    assert.strictEqual(found.options.operationName, 'foo');
+});
+
+test('findOperationOrThrow() throws with a description of the matcher object', async () => {
+    const client = createFakeGraphqlClient();
+
+    await client.queryOrThrow(simpleQuery, { operationName: 'foo' });
+
+    try {
+        client.findOperationOrThrow({ operationName: 'bar', type: 'mutation' });
+        assert.fail('Expected findOperationOrThrow() to throw but it did not');
+    } catch (error: unknown) {
+        assert.strictEqual(
+            (error as Error).message,
+            'No operation recorded matching { operationName=bar, type=mutation }'
+        );
+    }
+});
+
+test('findOperationOrThrow() throws with predicate description for predicate matchers', () => {
+    const client = createFakeGraphqlClient();
+
+    try {
+        client.findOperationOrThrow(() => {
+            return true;
+        });
+        assert.fail('Expected findOperationOrThrow() to throw but it did not');
+    } catch (error: unknown) {
+        assert.strictEqual((error as Error).message, 'No operation recorded matching predicate function');
+    }
+});

--- a/source/zod-graphql-fake-client/fake-client.ts
+++ b/source/zod-graphql-fake-client/fake-client.ts
@@ -9,14 +9,33 @@ import type {
 import {
     buildOperationPayload,
     type GraphqlOverHttpOperationRequestPayload,
-    type OperationOptions
+    type OperationOptions,
+    type OperationType
 } from '../zod-graphql-client/operation-payload.js';
+
+export type RecordedOperation = {
+    readonly type: OperationType;
+    readonly schema: QuerySchema;
+    readonly payload: GraphqlOverHttpOperationRequestPayload;
+    readonly options: OperationOptions;
+};
+
+export type OperationMatcherObject = {
+    readonly operationName?: string;
+    readonly type?: OperationType;
+    readonly schema?: QuerySchema;
+};
+
+export type OperationMatcher = OperationMatcherObject | ((recorded: RecordedOperation) => boolean);
 
 export type FakeGraphqlClient = GraphqlClient & {
     readonly inspectOperationPayload: (index: number) => GraphqlOverHttpOperationRequestPayload;
     readonly inspectFirstOperationPayload: () => GraphqlOverHttpOperationRequestPayload;
     readonly inspectOperationOptions: (index: number) => OperationOptions;
     readonly inspectFirstOperationOptions: () => OperationOptions;
+    readonly findOperation: (matcher: OperationMatcher) => RecordedOperation | undefined;
+    readonly findOperationOrThrow: (matcher: OperationMatcher) => RecordedOperation;
+    readonly findAllOperations: (matcher: OperationMatcher) => readonly RecordedOperation[];
 };
 
 type FakeSuccessData = {
@@ -34,22 +53,84 @@ export type FakeResult = FakeFailureResult | FakeSuccessData;
 type FakeClientOptions = {
     readonly results?: FakeResult[];
 };
+
+function operationMatchesObject(matcher: OperationMatcherObject, recorded: RecordedOperation): boolean {
+    const nameMatches = matcher.operationName === undefined ||
+        recorded.options.operationName === matcher.operationName;
+    const typeMatches = matcher.type === undefined || recorded.type === matcher.type;
+    const schemaMatches = matcher.schema === undefined || recorded.schema === matcher.schema;
+    return nameMatches && typeMatches && schemaMatches;
+}
+
+function operationMatches(matcher: OperationMatcher, recorded: RecordedOperation): boolean {
+    if (typeof matcher === 'function') {
+        return matcher(recorded);
+    }
+    return operationMatchesObject(matcher, recorded);
+}
+
+function describeMatcherObject(matcher: OperationMatcherObject): string {
+    const parts: string[] = [];
+    if (matcher.operationName !== undefined) {
+        parts.push(`operationName=${matcher.operationName}`);
+    }
+    if (matcher.type !== undefined) {
+        parts.push(`type=${matcher.type}`);
+    }
+    if (matcher.schema !== undefined) {
+        parts.push('schema=<schema>');
+    }
+    return parts.length === 0 ? '{}' : `{ ${parts.join(', ')} }`;
+}
+
+function describeMatcher(matcher: OperationMatcher): string {
+    if (typeof matcher === 'function') {
+        return 'predicate function';
+    }
+    return describeMatcherObject(matcher);
+}
+
+type OperationFinders = {
+    readonly findOperation: (matcher: OperationMatcher) => RecordedOperation | undefined;
+    readonly findAllOperations: (matcher: OperationMatcher) => readonly RecordedOperation[];
+    readonly findOperationOrThrow: (matcher: OperationMatcher) => RecordedOperation;
+};
+
+function buildOperationFinders(recordedOperations: readonly RecordedOperation[]): OperationFinders {
+    function findOperation(matcher: OperationMatcher): RecordedOperation | undefined {
+        return recordedOperations.find((recorded) => {
+            return operationMatches(matcher, recorded);
+        });
+    }
+    function findAllOperations(matcher: OperationMatcher): readonly RecordedOperation[] {
+        return recordedOperations.filter((recorded) => {
+            return operationMatches(matcher, recorded);
+        });
+    }
+    function findOperationOrThrow(matcher: OperationMatcher): RecordedOperation {
+        const recorded = findOperation(matcher);
+        if (recorded === undefined) {
+            throw new Error(`No operation recorded matching ${describeMatcher(matcher)}`);
+        }
+        return recorded;
+    }
+    return { findOperation, findAllOperations, findOperationOrThrow };
+}
+
 export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): FakeGraphqlClient {
     const { results = [] } = clientOptions;
-    const operationPayloads: GraphqlOverHttpOperationRequestPayload[] = [];
-    const operationOptions: OperationOptions[] = [];
+    const recordedOperations: RecordedOperation[] = [];
     const defaultResult: FakeResult = { data: {} };
 
     async function collectOperation<Schema extends QuerySchema>(
         schema: Schema,
-        type: 'mutation' | 'query',
+        type: OperationType,
         options: OperationOptions = {}
     ): Promise<OperationResult<Schema>> {
         const payload = buildOperationPayload(schema, type, options);
-        const result = results[operationPayloads.length] ?? defaultResult;
+        const result = results[recordedOperations.length] ?? defaultResult;
 
-        operationPayloads.push(payload);
-        operationOptions.push(options);
+        recordedOperations.push({ type, schema, payload, options });
 
         if (result.error !== undefined) {
             return { success: false, errorDetails: result.error };
@@ -72,22 +153,24 @@ export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): 
     }
 
     function inspectOperationPayload(index: number): GraphqlOverHttpOperationRequestPayload {
-        const payload = operationPayloads[index];
-        if (payload === undefined) {
+        const recorded = recordedOperations[index];
+        if (recorded === undefined) {
             throw new Error(`No query payload at index ${index} recorded`);
         }
 
-        return payload;
+        return recorded.payload;
     }
 
     function inspectOperationOptions(index: number): OperationOptions {
-        const operationOption = operationOptions[index];
-        if (operationOption === undefined) {
+        const recorded = recordedOperations[index];
+        if (recorded === undefined) {
             throw new Error(`No operationOption at index ${index} recorded`);
         }
 
-        return operationOption;
+        return recorded.options;
     }
+
+    const { findOperation, findAllOperations, findOperationOrThrow } = buildOperationFinders(recordedOperations);
 
     return {
         query,
@@ -110,6 +193,9 @@ export function createFakeGraphqlClient(clientOptions: FakeClientOptions = {}): 
         inspectOperationOptions,
         inspectFirstOperationOptions() {
             return inspectOperationOptions(0);
-        }
+        },
+        findOperation,
+        findOperationOrThrow,
+        findAllOperations
     };
 }


### PR DESCRIPTION
Inspection by call index breaks when test setup or production code changes call order. Add findOperation, findOperationOrThrow and findAllOperations that select recorded operations by an OperationMatcher — an object combining operationName, operation type and schema identity, or a predicate over the recorded operation. The positional inspect* methods stay for back-compat.