### PR TITLE
Add Automatic Persisted Queries support to the GraphQL client

### DIFF
--- a/source/zod-graphql-client/client.test.ts
+++ b/source/zod-graphql-client/client.test.ts
@@ -1,7 +1,7 @@
 import { test } from '@sondr3/minitest';
 import { TimeoutError } from 'ky';
 import assert from 'node:assert';
-import { fake, type SinonSpy } from 'sinon';
+import { fake, type SinonSpy, stub } from 'sinon';
 import { z } from 'zod/v4';
 import { graphqlFieldOptions, variablePlaceholder } from '../zod-graphql-query-builder/entry-point.js';
 import {
@@ -11,6 +11,7 @@ import {
     type GraphqlClient
 } from './client.js';
 import { GraphqlOperationError } from './operation-error.js';
+import { computePersistedQueryHash } from './persisted-query.js';
 
 type KyOverrides = {
     responseStatus?: number;
@@ -41,6 +42,14 @@ function clientFactory(overrides: Overrides): GraphqlClient {
     const { post = createFakeKyMethod(), options = { endpoint: '' } } = overrides;
     const createClient = createClientFactory({ ky: { post } } as unknown as CreateClientDependencies);
     return createClient(options);
+}
+
+function createKyMethodReturningResponses(responseBodies: readonly unknown[]): SinonSpy {
+    const sequence = stub();
+    responseBodies.forEach((body, index) => {
+        sequence.onCall(index).resolves({ status: 200, json: fake.resolves(body) });
+    });
+    return sequence as unknown as SinonSpy;
 }
 
 const simpleQuerySchema = z.strictObject({ foo: z.string() });
@@ -425,4 +434,179 @@ test('mutateOrThrow() rejects an error when there is a failure', async () => {
             issues: ['at foo: missing property; expected string']
         });
     }
+});
+
+const simpleQueryHash = computePersistedQueryHash('query { foo }');
+const mutationHash = computePersistedQueryHash('mutation { foo }');
+const persistedQueryEndpoint = 'http://example/endpoint';
+const persistedQueryOptions: ClientOptions = { endpoint: persistedQueryEndpoint, persistedQueries: true };
+
+function buildExpectedRequestArgs(json: unknown): [string, unknown] {
+    return [persistedQueryEndpoint, {
+        headers: {},
+        json,
+        retry: 0,
+        throwHttpErrors: false,
+        timeout: 10_000
+    }];
+}
+
+test('query() with persistedQueries sends only the hash on the first attempt', async () => {
+    const post = createKyMethodReturningResponses([{ data: { foo: 'bar' } }]);
+    const client = clientFactory({ post, options: persistedQueryOptions });
+
+    const result = await client.query(simpleQuerySchema);
+
+    assert.deepStrictEqual(
+        post.firstCall.args,
+        buildExpectedRequestArgs({
+            operationName: undefined,
+            variables: {},
+            extensions: { persistedQuery: { version: 1, sha256Hash: simpleQueryHash } }
+        })
+    );
+    assert.strictEqual(post.secondCall, null);
+    assert.deepStrictEqual(result, { success: true, data: { foo: 'bar' } });
+});
+
+test('query() with persistedQueries retries with the full query on PersistedQueryNotFound', async () => {
+    const post = createKyMethodReturningResponses([
+        { errors: [{ message: 'PersistedQueryNotFound' }] },
+        { data: { foo: 'bar' } }
+    ]);
+    const client = clientFactory({ post, options: persistedQueryOptions });
+
+    const result = await client.query(simpleQuerySchema);
+
+    assert.deepStrictEqual(
+        post.firstCall.args,
+        buildExpectedRequestArgs({
+            operationName: undefined,
+            variables: {},
+            extensions: { persistedQuery: { version: 1, sha256Hash: simpleQueryHash } }
+        })
+    );
+    assert.deepStrictEqual(
+        post.secondCall.args,
+        buildExpectedRequestArgs({
+            operationName: undefined,
+            query: 'query { foo }',
+            variables: {},
+            extensions: { persistedQuery: { version: 1, sha256Hash: simpleQueryHash } }
+        })
+    );
+    assert.strictEqual(post.thirdCall, null);
+    assert.deepStrictEqual(result, { success: true, data: { foo: 'bar' } });
+});
+
+test('query() with persistedQueries retries with the plain query on PersistedQueryNotSupported', async () => {
+    const post = createKyMethodReturningResponses([
+        { errors: [{ message: 'PersistedQueryNotSupported' }] },
+        { data: { foo: 'bar' } }
+    ]);
+    const client = clientFactory({ post, options: persistedQueryOptions });
+
+    const result = await client.query(simpleQuerySchema);
+
+    assert.deepStrictEqual(
+        post.secondCall.args,
+        buildExpectedRequestArgs({
+            operationName: undefined,
+            query: 'query { foo }',
+            variables: {}
+        })
+    );
+    assert.strictEqual(post.thirdCall, null);
+    assert.deepStrictEqual(result, { success: true, data: { foo: 'bar' } });
+});
+
+test('query() with persistedQueries surfaces unrelated GraphQL errors without retrying', async () => {
+    const post = createKyMethodReturningResponses([{ errors: [{ message: 'real failure' }] }]);
+    const client = clientFactory({ post, options: persistedQueryOptions });
+
+    const result = await client.query(simpleQuerySchema);
+
+    assert.strictEqual(post.callCount, 1);
+    assert.deepStrictEqual(result, {
+        success: false,
+        errorDetails: { type: 'graphql', message: 'GraphQL response contains errors', errors: ['real failure'] }
+    });
+});
+
+test('mutate() with persistedQueries follows the same retry-on-not-found behavior as queries', async () => {
+    const post = createKyMethodReturningResponses([
+        { errors: [{ message: 'PersistedQueryNotFound' }] },
+        { data: { foo: 'bar' } }
+    ]);
+    const client = clientFactory({ post, options: persistedQueryOptions });
+
+    const result = await client.mutate(simpleQuerySchema);
+
+    assert.deepStrictEqual(
+        post.firstCall.args,
+        buildExpectedRequestArgs({
+            operationName: undefined,
+            variables: {},
+            extensions: { persistedQuery: { version: 1, sha256Hash: mutationHash } }
+        })
+    );
+    assert.deepStrictEqual(
+        post.secondCall.args,
+        buildExpectedRequestArgs({
+            operationName: undefined,
+            query: 'mutation { foo }',
+            variables: {},
+            extensions: { persistedQuery: { version: 1, sha256Hash: mutationHash } }
+        })
+    );
+    assert.deepStrictEqual(result, { success: true, data: { foo: 'bar' } });
+});
+
+test('query() with persistedQueries does not retry past one attempt on persistent PersistedQueryNotFound', async () => {
+    const post = createKyMethodReturningResponses([
+        { errors: [{ message: 'PersistedQueryNotFound' }] },
+        { errors: [{ message: 'PersistedQueryNotFound' }] }
+    ]);
+    const client = clientFactory({ post, options: persistedQueryOptions });
+
+    const result = await client.query(simpleQuerySchema);
+
+    assert.strictEqual(post.thirdCall, null);
+    assert.deepStrictEqual(result, {
+        success: false,
+        errorDetails: {
+            type: 'graphql',
+            message: 'GraphQL response contains errors',
+            errors: ['PersistedQueryNotFound']
+        }
+    });
+});
+
+test('query() with persistedQueries returns the network failure when the first attempt errors', async () => {
+    const post = createFakeKyMethod({ error: new Error('network down') });
+    const client = clientFactory({ post, options: persistedQueryOptions });
+
+    const result = await client.query(simpleQuerySchema);
+
+    assert.strictEqual(post.secondCall, null);
+    assert.deepStrictEqual(result, {
+        success: false,
+        errorDetails: { type: 'network', message: 'network down' }
+    });
+});
+
+test('query() without persistedQueries never includes the extensions field', async () => {
+    const post = createFakeKyMethod({ responseJsonBody: { data: { foo: 'bar' } } });
+    const client = clientFactory({ post, options: { endpoint: persistedQueryEndpoint } });
+
+    await client.query(simpleQuerySchema);
+
+    assert.deepStrictEqual(
+        post.firstCall.args,
+        buildExpectedRequestArgs({
+            operationName: undefined,
+            query: 'query { foo }',
+            variables: {}
+        })
+    );
 });

--- a/source/zod-graphql-client/client.ts
+++ b/source/zod-graphql-client/client.ts
@@ -4,8 +4,15 @@ import { safeParse } from '../zod-error-formatter/formatter.js';
 import type { QuerySchema } from '../zod-graphql-query-builder/entry-point.js';
 import { parseGraphqlResponse } from './graphql-response.js';
 import { GraphqlOperationError } from './operation-error.js';
-import { buildOperationPayload, type OperationOptions } from './operation-payload.js';
+import {
+    buildOperationPayload,
+    type BuiltOperationPayload,
+    type GraphqlOverHttpOperationRequestPayload,
+    type OperationOptions,
+    toPersistedQueryPayload
+} from './operation-payload.js';
 import type { OperationFailureResult, OperationResult, OperationResultForType } from './operation-result.js';
+import { detectPersistedQueryRetryReason } from './persisted-query.js';
 
 export type { OperationOptions } from './operation-payload.js';
 
@@ -13,6 +20,7 @@ export type ClientOptions = {
     endpoint: string;
     headers?: Record<string, string | undefined>;
     timeout?: number;
+    persistedQueries?: boolean;
 };
 
 export type GraphqlClient = {
@@ -48,6 +56,59 @@ export function extractDataOrThrow<Data>(result: OperationResultForType<Data>): 
         return result.data;
     }
     throw new GraphqlOperationError(result.errorDetails);
+}
+
+async function parseServerResponse(response: Response): Promise<OperationResultForType<unknown>> {
+    try {
+        const responseBody = await response.json() as unknown;
+        return {
+            success: true,
+            data: responseBody
+        };
+    } catch (error: unknown) {
+        const causedByMessage = error instanceof Error ? `: ${error.message}` : '';
+
+        return {
+            success: false,
+            errorDetails: {
+                type: 'server',
+                statusCode: response.status,
+                message: `Failed to parse response body${causedByMessage}`
+            }
+        };
+    }
+}
+
+function parseResponseData<Schema extends QuerySchema>(schema: Schema, data: unknown): OperationResult<Schema> {
+    const dataParseResult = safeParse(schema, data);
+
+    if (dataParseResult.success) {
+        return {
+            success: true,
+            data: dataParseResult.data as TypeOf<Schema>
+        };
+    }
+
+    return {
+        success: false,
+        errorDetails: {
+            type: 'validation',
+            message: 'GraphQL response data doesn’t match the expected schema',
+            issues: dataParseResult.error.issues
+        }
+    };
+}
+
+function parseAndValidate<Schema extends QuerySchema>(
+    schema: Schema,
+    rawResponse: unknown
+): OperationResult<Schema> {
+    const graphqlResponseParseResult = parseGraphqlResponse(rawResponse);
+
+    if (graphqlResponseParseResult.success) {
+        return parseResponseData(schema, graphqlResponseParseResult.data);
+    }
+    return graphqlResponseParseResult;
 }
 
 function mapUnknownNetworkErrorToFailureResult(error: unknown, timeout: number): OperationFailureResult {
@@ -95,47 +156,6 @@ export function createClientFactory(dependencies: CreateClientDependencies): Cre
             };
         }
 
-        async function parseServerResponse(response: Response): Promise<OperationResultForType<unknown>> {
-            try {
-                const responseBody = await response.json() as unknown;
-                return {
-                    success: true,
-                    data: responseBody
-                };
-            } catch (error: unknown) {
-                const causedByMessage = error instanceof Error ? `: ${error.message}` : '';
-
-                return {
-                    success: false,
-                    errorDetails: {
-                        type: 'server',
-                        statusCode: response.status,
-                        message: `Failed to parse response body${causedByMessage}`
-                    }
-                };
-            }
-        }
-
-        function parseResponseData<Schema extends QuerySchema>(schema: Schema, data: unknown): OperationResult<Schema> {
-            const dataParseResult = safeParse(schema, data);
-
-            if (dataParseResult.success) {
-                return {
-                    success: true,
-                    data: dataParseResult.data as TypeOf<Schema>
-                };
-            }
-
-            return {
-                success: false,
-                errorDetails: {
-                    type: 'validation',
-                    message: 'GraphQL response data doesn’t match the expected schema',
-                    issues: dataParseResult.error.issues
-                }
-            };
-        }
-
         async function fetchGraphqlEndpoint(
             options: OperationOptions,
             payload: unknown
@@ -164,6 +184,41 @@ export function createClientFactory(dependencies: CreateClientDependencies): Cre
             }
         }
 
+        async function fetchAndParse<Schema extends QuerySchema>(
+            schema: Schema,
+            options: OperationOptions,
+            payload: GraphqlOverHttpOperationRequestPayload
+        ): Promise<OperationResult<Schema>> {
+            const serverResponseParseResult = await fetchGraphqlEndpoint(options, payload);
+            if (!serverResponseParseResult.success) {
+                return serverResponseParseResult;
+            }
+            return parseAndValidate(schema, serverResponseParseResult.data);
+        }
+
+        async function performPersistedQueryOperation<Schema extends QuerySchema>(
+            schema: Schema,
+            options: OperationOptions,
+            basePayload: BuiltOperationPayload
+        ): Promise<OperationResult<Schema>> {
+            const hashOnlyPayload = toPersistedQueryPayload(basePayload, 'hash-only');
+            const firstAttempt = await fetchGraphqlEndpoint(options, hashOnlyPayload);
+
+            if (!firstAttempt.success) {
+                return firstAttempt;
+            }
+
+            const retryReason = detectPersistedQueryRetryReason(firstAttempt.data);
+            if (retryReason === undefined) {
+                return parseAndValidate(schema, firstAttempt.data);
+            }
+
+            const retryPayload = retryReason === 'not-supported' ?
+                basePayload :
+                toPersistedQueryPayload(basePayload, 'hash-and-query');
+            return fetchAndParse(schema, options, retryPayload);
+        }
+
         async function performOperation<Schema extends QuerySchema>(
             schema: Schema,
             operationType: 'mutation' | 'query',
@@ -171,18 +226,11 @@ export function createClientFactory(dependencies: CreateClientDependencies): Cre
         ): Promise<OperationResult<Schema>> {
             const payload = buildOperationPayload(schema, operationType, options);
 
-            const serverResponseParseResult = await fetchGraphqlEndpoint(options, payload);
-
-            if (serverResponseParseResult.success) {
-                const graphqlResponseParseResult = parseGraphqlResponse(serverResponseParseResult.data);
-
-                if (graphqlResponseParseResult.success) {
-                    return parseResponseData(schema, graphqlResponseParseResult.data);
-                }
-                return graphqlResponseParseResult;
+            if (clientOptions.persistedQueries === true) {
+                return performPersistedQueryOperation(schema, options, payload);
             }
 
-            return serverResponseParseResult;
+            return fetchAndParse(schema, options, payload);
         }
 
         async function query<Schema extends QuerySchema>(

--- a/source/zod-graphql-client/operation-payload.ts
+++ b/source/zod-graphql-client/operation-payload.ts
@@ -1,4 +1,5 @@
 import { buildGraphqlMutation, buildGraphqlQuery, type QuerySchema } from '../zod-graphql-query-builder/entry-point.js';
+import { buildPersistedQueryExtensions, type PersistedQueryExtensions } from './persisted-query.js';
 import { extractVariableDefinitions, extractVariableValues, type Variables } from './variables.js';
 
 export type OperationType = 'mutation' | 'query';
@@ -11,6 +12,13 @@ export type OperationOptions = {
 };
 
 export type GraphqlOverHttpOperationRequestPayload = {
+    query?: string;
+    variables: Record<string, unknown>;
+    operationName?: string | undefined;
+    extensions?: PersistedQueryExtensions;
+};
+
+export type BuiltOperationPayload = {
     query: string;
     variables: Record<string, unknown>;
     operationName?: string | undefined;
@@ -20,7 +28,7 @@ export function buildOperationPayload(
     schema: QuerySchema,
     operationType: OperationType,
     options: OperationOptions
-): GraphqlOverHttpOperationRequestPayload {
+): BuiltOperationPayload {
     const { variables = {} } = options;
     const variableDefinitions = extractVariableDefinitions(variables);
     const variableValues = extractVariableValues(variables);
@@ -39,5 +47,27 @@ export function buildOperationPayload(
         query: serializedQuery,
         variables: variableValues,
         operationName: options.operationName
+    };
+}
+
+export type PersistedQueryPayloadMode = 'hash-and-query' | 'hash-only';
+
+export function toPersistedQueryPayload(
+    payload: BuiltOperationPayload,
+    mode: PersistedQueryPayloadMode
+): GraphqlOverHttpOperationRequestPayload {
+    const extensions = buildPersistedQueryExtensions(payload.query);
+    if (mode === 'hash-only') {
+        return {
+            variables: payload.variables,
+            operationName: payload.operationName,
+            extensions
+        };
+    }
+    return {
+        query: payload.query,
+        variables: payload.variables,
+        operationName: payload.operationName,
+        extensions
     };
 }

--- a/source/zod-graphql-client/persisted-query.test.ts
+++ b/source/zod-graphql-client/persisted-query.test.ts
@@ -1,0 +1,82 @@
+import { test } from '@sondr3/minitest';
+import assert from 'node:assert';
+import {
+    buildPersistedQueryExtensions,
+    computePersistedQueryHash,
+    detectPersistedQueryRetryReason
+} from './persisted-query.js';
+
+const queryFooHash = '6aa12cae7e116b726dae8e1ea59ab89ea8b16b7d596c834341d10ca36e12efd6';
+
+test('computePersistedQueryHash returns the sha256 hex digest of the given query', () => {
+    assert.strictEqual(computePersistedQueryHash('query { foo }'), queryFooHash);
+});
+
+test('buildPersistedQueryExtensions wraps the hash with the version 1 envelope', () => {
+    assert.deepStrictEqual(buildPersistedQueryExtensions('query { foo }'), {
+        persistedQuery: {
+            version: 1,
+            sha256Hash: queryFooHash
+        }
+    });
+});
+
+test('detectPersistedQueryRetryReason returns undefined when the response is not an object', () => {
+    assert.strictEqual(detectPersistedQueryRetryReason('not an object'), undefined);
+});
+
+test('detectPersistedQueryRetryReason returns undefined when there is no errors property', () => {
+    assert.strictEqual(detectPersistedQueryRetryReason({ data: { foo: 'bar' } }), undefined);
+});
+
+test('detectPersistedQueryRetryReason returns undefined when errors do not contain persisted query signals', () => {
+    assert.strictEqual(
+        detectPersistedQueryRetryReason({ errors: [{ message: 'some other error' }] }),
+        undefined
+    );
+});
+
+test('detectPersistedQueryRetryReason returns "not-found" on PersistedQueryNotFound message', () => {
+    assert.strictEqual(
+        detectPersistedQueryRetryReason({ errors: [{ message: 'PersistedQueryNotFound' }] }),
+        'not-found'
+    );
+});
+
+test('detectPersistedQueryRetryReason returns "not-found" on PERSISTED_QUERY_NOT_FOUND extension code', () => {
+    assert.strictEqual(
+        detectPersistedQueryRetryReason({
+            errors: [{ message: 'whatever', extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' } }]
+        }),
+        'not-found'
+    );
+});
+
+test('detectPersistedQueryRetryReason returns "not-supported" on PersistedQueryNotSupported message', () => {
+    assert.strictEqual(
+        detectPersistedQueryRetryReason({ errors: [{ message: 'PersistedQueryNotSupported' }] }),
+        'not-supported'
+    );
+});
+
+test('detectPersistedQueryRetryReason returns "not-supported" on PERSISTED_QUERY_NOT_SUPPORTED extension code', () => {
+    assert.strictEqual(
+        detectPersistedQueryRetryReason({
+            errors: [{ message: 'whatever', extensions: { code: 'PERSISTED_QUERY_NOT_SUPPORTED' } }]
+        }),
+        'not-supported'
+    );
+});
+
+test('detectPersistedQueryRetryReason returns the first matching reason when multiple errors are present', () => {
+    assert.strictEqual(
+        detectPersistedQueryRetryReason({
+            errors: [{ message: 'unrelated' }, { message: 'PersistedQueryNotFound' }]
+        }),
+        'not-found'
+    );
+});
+
+test('detectPersistedQueryRetryReason returns undefined for a malformed response shape', () => {
+    assert.strictEqual(detectPersistedQueryRetryReason({ errors: 'not-an-array' }), undefined);
+});

--- a/source/zod-graphql-client/persisted-query.ts
+++ b/source/zod-graphql-client/persisted-query.ts
@@ -1,0 +1,71 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod/v4-mini';
+
+const persistedQueryVersion = 1;
+
+export type PersistedQueryExtensions = {
+    persistedQuery: {
+        version: typeof persistedQueryVersion;
+        sha256Hash: string;
+    };
+};
+
+export function computePersistedQueryHash(query: string): string {
+    return createHash('sha256').update(query).digest('hex');
+}
+
+export function buildPersistedQueryExtensions(query: string): PersistedQueryExtensions {
+    return {
+        persistedQuery: {
+            version: persistedQueryVersion,
+            sha256Hash: computePersistedQueryHash(query)
+        }
+    };
+}
+
+const persistedQueryNotFoundMessage = 'PersistedQueryNotFound';
+const persistedQueryNotFoundCode = 'PERSISTED_QUERY_NOT_FOUND';
+const persistedQueryNotSupportedMessage = 'PersistedQueryNotSupported';
+const persistedQueryNotSupportedCode = 'PERSISTED_QUERY_NOT_SUPPORTED';
+
+const persistedQueryErrorDetectionSchema = z.object({
+    errors: z.optional(z.array(z.object({
+        message: z.optional(z.string()),
+        extensions: z.optional(z.object({
+            code: z.optional(z.string())
+        }))
+    })))
+});
+
+export type PersistedQueryRetryReason = 'not-found' | 'not-supported';
+
+type GraphqlErrorShape = {
+    message?: string | undefined;
+    extensions?: { code?: string | undefined; } | undefined;
+};
+
+function classifyPersistedQueryError(error: GraphqlErrorShape): PersistedQueryRetryReason | undefined {
+    const code = error.extensions?.code;
+    if (error.message === persistedQueryNotFoundMessage || code === persistedQueryNotFoundCode) {
+        return 'not-found';
+    }
+    if (error.message === persistedQueryNotSupportedMessage || code === persistedQueryNotSupportedCode) {
+        return 'not-supported';
+    }
+    return undefined;
+}
+
+export function detectPersistedQueryRetryReason(rawResponse: unknown): PersistedQueryRetryReason | undefined {
+    const parsed = persistedQueryErrorDetectionSchema.safeParse(rawResponse);
+    if (!parsed.success || parsed.data.errors === undefined) {
+        return undefined;
+    }
+
+    for (const error of parsed.data.errors) {
+        const reason = classifyPersistedQueryError(error);
+        if (reason !== undefined) {
+            return reason;
+        }
+    }
+    return undefined;
+}

--- a/source/zod-graphql-client/readme.md
+++ b/source/zod-graphql-client/readme.md
@@ -59,6 +59,7 @@ You can further customize the client by providing additional options:
 - `headers` (optional): A key-value map of additional headers that should be sent with every request. This can be useful for passing authentication tokens or other metadata to the server.
 - `timeout` (optional): The request timeout in milliseconds. This determines how long the client will wait for a response before considering the request failed. If not specified, a default timeout of 10 seconds (10,000 milliseconds) will be used.
 - `fetch` (optional): Allows you to inject a custom `fetch` function instead of using the global `fetch`. This can be useful in environments where the global `fetch` function is not available, or if you need to customize the behavior of the HTTP requests.
+- `persistedQueries` (optional): Enables [Automatic Persisted Queries (APQ)](#automatic-persisted-queries-apq) for every operation. Defaults to `false`.
 
 ### Sending a Query
 
@@ -183,6 +184,39 @@ Errors are distinguishable based on the `type` property within the `errorDetails
 ### `queryOrThrow()` and `mutateOrThrow()`
 
 The `queryOrThrow()` and `mutateOrThrow()` functions behaves similarly to `query()` and `mutate()`, but with one key difference in its return type. If the operation execution is successful, the function returns the operation result data directly. However, if an error occurs during the operation execution, it throws an instance of `GraphqlOperationError`. This custom error contains detailed information about the encountered error in its `details` property, which aligns with the `errorDetails` structure returned by the `operation()` function.
+
+### Automatic Persisted Queries (APQ)
+
+When `persistedQueries` is enabled on the client, every operation is first sent as the SHA-256 hash of the serialized query (no `query` body), following Apollo’s [Automatic Persisted Queries](https://www.apollographql.com/docs/apollo-server/performance/apq/) protocol:
+
+```typescript
+const client = createGraphqlClient({
+    endpoint: 'https://example.com/graphql',
+    persistedQueries: true
+});
+```
+
+The request payload sent to the server uses the standard APQ extension format:
+
+```json
+{
+    "operationName": "YourQueryName",
+    "variables": {},
+    "extensions": {
+        "persistedQuery": {
+            "version": 1,
+            "sha256Hash": "<sha256 of the serialized query>"
+        }
+    }
+}
+```
+
+The client automatically handles the two well-known APQ error responses:
+
+- **`PersistedQueryNotFound`**: The server doesn’t yet know this query. The client retries the same operation, this time including both the `query` text and the `extensions.persistedQuery` envelope, so the server can register the query under its hash for future requests.
+- **`PersistedQueryNotSupported`**: The server does not support APQ at all. The client retries the operation as a plain GraphQL request (no `extensions` field). Subsequent operations still attempt APQ — the client does not remember that the server doesn’t support it.
+
+Detection of these error responses is resilient: the client matches both on `errors[].message` (`PersistedQueryNotFound` / `PersistedQueryNotSupported`) and on `errors[].extensions.code` (`PERSISTED_QUERY_NOT_FOUND` / `PERSISTED_QUERY_NOT_SUPPORTED`).
 
 ### Re-exported Functions
 


### PR DESCRIPTION
Enabling the new `persistedQueries` client option sends every operation as a SHA-256 hash first and retries with the full query body on PersistedQueryNotFound, or as a plain GraphQL request on PersistedQueryNotSupported, following Apollo's APQ protocol.