### PR TITLE
Auto-hoist reused object schemas into named GraphQL fragments

### DIFF
--- a/source/zod-graphql-query-builder/builder.test.ts
+++ b/source/zod-graphql-query-builder/builder.test.ts
@@ -58,19 +58,6 @@ function checkQuery(testCase: QueryTestCase): TestFn {
     };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- recursive schema escapes the static type
-function createRecursiveUserSchema(): any {
-    const holder: { value: unknown; } = { value: null };
-    const userSchema = z.strictObject({
-        id: z.string(),
-        friends: z.array(z.lazy(() => {
-            return holder.value as never;
-        }))
-    });
-    holder.value = userSchema;
-    return userSchema;
-}
-
 (['query', 'mutation'] as const).forEach((operationType) => {
     test(
         `throws building the ${operationType} when a referenced variable is not defined`,
@@ -996,11 +983,16 @@ function createRecursiveUserSchema(): any {
         checkQuery({
             type: operationType,
             buildSchema(builder) {
-                /* eslint-disable @typescript-eslint/no-unsafe-assignment -- recursive schema escapes the static type */
-                const baseUserSchema = createRecursiveUserSchema();
+                const holder: { value: unknown; } = { value: null };
+                const baseUserSchema = z.strictObject({
+                    id: z.string(),
+                    friends: z.array(z.lazy(() => {
+                        return holder.value as never;
+                    }))
+                });
+                holder.value = baseUserSchema;
                 const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
                 return z.strictObject({ me: userSchema });
-                /* eslint-enable @typescript-eslint/no-unsafe-assignment -- end of recursive schema setup */
             },
             expectedQuery: `${operationType} { me { ...User_1 } } fragment User_1 on User { id, friends { ...User_1 } }`
         })
@@ -1011,10 +1003,15 @@ function createRecursiveUserSchema(): any {
         checkError({
             type: operationType,
             buildSchema() {
-                /* eslint-disable @typescript-eslint/no-unsafe-assignment -- recursive schema escapes the static type */
-                const userSchema = createRecursiveUserSchema();
+                const holder: { value: unknown; } = { value: null };
+                const userSchema = z.strictObject({
+                    id: z.string(),
+                    friends: z.array(z.lazy(() => {
+                        return holder.value as never;
+                    }))
+                });
+                holder.value = userSchema;
                 return z.strictObject({ me: userSchema });
-                /* eslint-enable @typescript-eslint/no-unsafe-assignment -- end of recursive schema setup */
             },
             expectedError: 'Cyclic schema detected without a resolvable GraphQL type name. ' +
                 "Register it with graphqlFieldOptions(schema, { typeName: '...' }) " +

--- a/source/zod-graphql-query-builder/builder.test.ts
+++ b/source/zod-graphql-query-builder/builder.test.ts
@@ -58,6 +58,19 @@ function checkQuery(testCase: QueryTestCase): TestFn {
     };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- recursive schema escapes the static type
+function createRecursiveUserSchema(): any {
+    const holder: { value: unknown; } = { value: null };
+    const userSchema = z.strictObject({
+        id: z.string(),
+        friends: z.array(z.lazy(() => {
+            return holder.value as never;
+        }))
+    });
+    holder.value = userSchema;
+    return userSchema;
+}
+
 (['query', 'mutation'] as const).forEach((operationType) => {
     test(
         `throws building the ${operationType} when a referenced variable is not defined`,
@@ -704,6 +717,325 @@ function checkQuery(testCase: QueryTestCase): TestFn {
             expectedQuery: `${operationType} { foo }`
         })
     );
+
+    test(
+        `builds a ${operationType} keeping a single-use typed schema inline`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserSchema = z.strictObject({ id: z.string(), name: z.string() });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                return z.strictObject({ me: userSchema });
+            },
+            expectedQuery: `${operationType} { me { id, name } }`
+        })
+    );
+
+    test(
+        `builds a ${operationType} hoisting a typed schema reused twice into a named fragment`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserSchema = z.strictObject({ id: z.string(), name: z.string() });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            expectedQuery:
+                `${operationType} { me { ...User_1 }, you { ...User_1 } } fragment User_1 on User { id, name }`
+        })
+    );
+
+    test(
+        `builds a ${operationType} sharing one fragment across three use sites`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserSchema = z.strictObject({ id: z.string() });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                return z.strictObject({ a: userSchema, b: userSchema, c: userSchema });
+            },
+            expectedQuery: oneLine`
+                ${operationType} { a { ...User_1 }, b { ...User_1 }, c { ...User_1 } }
+                fragment User_1 on User { id }
+            `
+        })
+    );
+
+    test(
+        `builds a ${operationType} keeping a reused schema inline when no typeName is registered`,
+        checkQuery({
+            type: operationType,
+            buildSchema() {
+                const userSchema = z.strictObject({ id: z.string(), name: z.string() });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            expectedQuery: `${operationType} { me { id, name }, you { id, name } }`
+        })
+    );
+
+    test(
+        `builds a ${operationType} deriving the typeName from a __typename literal on a reused schema`,
+        checkQuery({
+            type: operationType,
+            buildSchema() {
+                const userSchema = z.strictObject({
+                    __typename: z.literal('User'),
+                    id: z.string()
+                });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            expectedQuery: oneLine`
+                ${operationType} { me { ...User_1 }, you { ...User_1 } }
+                fragment User_1 on User { __typename, id }
+            `
+        })
+    );
+
+    test(
+        `throws building the ${operationType} when an explicit typeName conflicts with the __typename literal`,
+        checkError({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserSchema = z.strictObject({ __typename: z.literal('B'), id: z.string() });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'A' });
+                return z.strictObject({ first: userSchema, second: userSchema });
+            },
+            expectedError:
+                'Conflicting GraphQL type name for schema: registered as "A" but `__typename` literal is "B".'
+        })
+    );
+
+    test(
+        `builds a ${operationType} treating a non-literal __typename as no inferred typeName`,
+        checkQuery({
+            type: operationType,
+            buildSchema() {
+                const userSchema = z.strictObject({
+                    __typename: z.string(),
+                    id: z.string()
+                });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            expectedQuery: `${operationType} { me { __typename, id }, you { __typename, id } }`
+        })
+    );
+
+    test(
+        `builds a ${operationType} treating a non-string __typename literal as no inferred typeName`,
+        checkQuery({
+            type: operationType,
+            buildSchema() {
+                const userSchema = z.strictObject({
+                    // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- arbitrary non-string literal value
+                    __typename: z.literal(42),
+                    id: z.string()
+                });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            expectedQuery: `${operationType} { me { __typename, id }, you { __typename, id } }`
+        })
+    );
+
+    test(
+        `builds a ${operationType} treating an invalid identifier __typename literal as no inferred typeName`,
+        checkQuery({
+            type: operationType,
+            buildSchema() {
+                const userSchema = z.strictObject({
+                    __typename: z.literal('123-bad'),
+                    id: z.string()
+                });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            expectedQuery: `${operationType} { me { __typename, id }, you { __typename, id } }`
+        })
+    );
+
+    test(
+        `builds a ${operationType} hoisting discriminated-union options into fragments when the union is reused`,
+        checkQuery({
+            type: operationType,
+            buildSchema() {
+                const union = z.discriminatedUnion('__typename', [
+                    z.strictObject({ __typename: z.literal('A'), valueA: z.string() }),
+                    z.strictObject({ __typename: z.literal('B'), valueB: z.string() })
+                ]);
+                return z.strictObject({ first: union, second: union });
+            },
+            expectedQuery: oneLine`
+                ${operationType} { first { ...A_1, ...B_1 }, second { ...A_1, ...B_1 } }
+                fragment A_1 on A { __typename, valueA }
+                fragment B_1 on B { __typename, valueB }
+            `
+        })
+    );
+
+    test(
+        `builds a ${operationType} keeping single-use union options inline while hoisting reused ones`,
+        checkQuery({
+            type: operationType,
+            buildSchema() {
+                const sharedA = z.strictObject({ __typename: z.literal('A'), valueA: z.string() });
+                const union = z.discriminatedUnion('__typename', [
+                    sharedA,
+                    z.strictObject({ __typename: z.literal('B'), valueB: z.string() })
+                ]);
+                return z.strictObject({ direct: sharedA, mixed: union });
+            },
+            expectedQuery: oneLine`
+                ${operationType} { direct { ...A_1 }, mixed { ...A_1, ... on B { __typename, valueB } } }
+                fragment A_1 on A { __typename, valueA }
+            `
+        })
+    );
+
+    test(
+        `builds a ${operationType} emitting nested fragments for reused schemas inside reused schemas`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                const baseAddressSchema = z.strictObject({ street: z.string(), city: z.string() });
+                const addressSchema = builder.registerFieldOptions(baseAddressSchema, { typeName: 'Address' });
+                const baseUserSchema = z.strictObject({ id: z.string(), address: addressSchema });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            expectedQuery: oneLine`
+                ${operationType} { me { ...User_1 }, you { ...User_1 } }
+                fragment Address_1 on Address { street, city }
+                fragment User_1 on User { id, address { ...Address_1 } }
+            `
+        })
+    );
+
+    test(
+        `builds a ${operationType} propagating variables from inside a fragmented body to the operation`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserSchema = z.strictObject({
+                    id: z.string(),
+                    avatar: builder.registerFieldOptions(z.string(), {
+                        parameters: { size: variablePlaceholder('$size') }
+                    })
+                });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            operationOptions: { variableDefinitions: { $size: 'Int!' } },
+            expectedQuery: oneLine`
+                ${operationType} ($size: Int!) { me { ...User_1 }, you { ...User_1 } }
+                fragment User_1 on User { id, avatar(size: $size) }
+            `
+        })
+    );
+
+    test(
+        `throws building the ${operationType} when a variable referenced inside a fragment is not declared`,
+        checkError({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserSchema = z.strictObject({
+                    id: z.string(),
+                    avatar: builder.registerFieldOptions(z.string(), {
+                        parameters: { size: variablePlaceholder('$size') }
+                    })
+                });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                return z.strictObject({ me: userSchema, you: userSchema });
+            },
+            operationOptions: {},
+            expectedError: 'Referenced variable "$size" is missing in variableDefinitions'
+        })
+    );
+
+    test(
+        `builds a ${operationType} disambiguating two distinct schemas registered with the same typeName`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserA = z.strictObject({ id: z.string() });
+                const userA = builder.registerFieldOptions(baseUserA, { typeName: 'User' });
+                const baseUserB = z.strictObject({ id: z.string(), name: z.string() });
+                const userB = builder.registerFieldOptions(baseUserB, { typeName: 'User' });
+                return z.strictObject({
+                    a1: userA,
+                    a2: userA,
+                    b1: userB,
+                    b2: userB
+                });
+            },
+            expectedQuery: oneLine`
+                ${operationType} { a1 { ...User_1 }, a2 { ...User_1 }, b1 { ...User_2 }, b2 { ...User_2 } }
+                fragment User_1 on User { id }
+                fragment User_2 on User { id, name }
+            `
+        })
+    );
+
+    test(
+        `builds a ${operationType} deduping the same object reached through a wrapper and a plain reference`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                const baseUserSchema = z.strictObject({ id: z.string() });
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                const wrappedUserSchema = z.nullable(userSchema);
+                return z.strictObject({
+                    plain: userSchema,
+                    wrapped: wrappedUserSchema
+                });
+            },
+            expectedQuery:
+                `${operationType} { plain { ...User_1 }, wrapped { ...User_1 } } fragment User_1 on User { id }`
+        })
+    );
+
+    test(
+        `builds a ${operationType} producing a self-recursive fragment for a cyclic typed schema`,
+        checkQuery({
+            type: operationType,
+            buildSchema(builder) {
+                /* eslint-disable @typescript-eslint/no-unsafe-assignment -- recursive schema escapes the static type */
+                const baseUserSchema = createRecursiveUserSchema();
+                const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
+                return z.strictObject({ me: userSchema });
+                /* eslint-enable @typescript-eslint/no-unsafe-assignment -- end of recursive schema setup */
+            },
+            expectedQuery: `${operationType} { me { ...User_1 } } fragment User_1 on User { id, friends { ...User_1 } }`
+        })
+    );
+
+    test(
+        `throws building the ${operationType} when a cyclic schema has no resolvable typeName`,
+        checkError({
+            type: operationType,
+            buildSchema() {
+                /* eslint-disable @typescript-eslint/no-unsafe-assignment -- recursive schema escapes the static type */
+                const userSchema = createRecursiveUserSchema();
+                return z.strictObject({ me: userSchema });
+                /* eslint-enable @typescript-eslint/no-unsafe-assignment -- end of recursive schema setup */
+            },
+            expectedError: 'Cyclic schema detected without a resolvable GraphQL type name. ' +
+                "Register it with graphqlFieldOptions(schema, { typeName: '...' }) " +
+                "or add `__typename: z.literal('...')` to its shape so the builder can emit a named fragment."
+        })
+    );
+});
+
+test('throws at registration when typeName is not a valid GraphQL identifier', () => {
+    const builder = createQueryBuilder();
+    const baseSchema = z.strictObject({ id: z.string() });
+
+    try {
+        builder.registerFieldOptions(baseSchema, { typeName: 'bad-name!' });
+        assert.fail('Expected registerFieldOptions to throw');
+    } catch (error: unknown) {
+        assert.strictEqual(
+            (error as Error).message,
+            'Invalid GraphQL type name: "bad-name!". A type name must match /^[A-Z_a-z]\\w*$/.'
+        );
+    }
 });
 
 test('a schema with custom scalar validates correctly', () => {

--- a/source/zod-graphql-query-builder/builder.ts
+++ b/source/zod-graphql-query-builder/builder.ts
@@ -1,55 +1,17 @@
 /* eslint-disable no-underscore-dangle -- we need to access _zod */
+import { $ZodReadonly } from 'zod/v4/core';
+import type { FieldSchema, FieldShape, QuerySchema, StrictObjectSchema } from './query-schema.js';
 import {
-    $ZodArray,
-    $ZodDiscriminatedUnion,
-    $ZodLiteral,
-    $ZodReadonly,
-    $ZodUndefined,
-    type util
-} from 'zod/v4/core';
-import { isCustomScalarSchema } from './custom-scalar.js';
-import {
-    type FieldArray,
-    type FieldSchema,
-    type FieldSchemaTuple,
-    type FieldShape,
-    type FragmentsSchema,
-    type FragmentUnionOptionSchema,
-    isFragmentsSchema,
-    isObjectOrListSchema,
-    isStrictObjectSchema,
-    isUnionOrListSchema,
-    type NonWrappedFieldSchema,
-    type ObjectOrListSchema,
-    type QuerySchema,
-    type StrictObjectSchema,
-    type UnionOrListSchema,
-    unwrapFieldSchema,
-    unwrapFieldSchemaChain
-} from './query-schema.js';
+    type BuildContext,
+    collectSchemaReferences,
+    type FieldOptionsRegistry,
+    type FragmentDefinition,
+    type GraphqlFieldOptions,
+    serializeRootShape
+} from './serializer.js';
 import { isValidGraphqlName } from './values/name.js';
-import { normalizeParameterList } from './values/parameter-list.js';
-import type { GraphqlValue, NormalizedGraphqlValue } from './values/value.js';
-import { mergeVariables } from './values/variable-set.js';
 import { ensureValidVariableCorrelations } from './variable-correlations.js';
 import { serializeVariableDefinitions, type VariableDefinitions } from './variable-definition.js';
-
-function withTrailingSpace(value: string): string {
-    if (value.length === 0) {
-        return value;
-    }
-    return `${value} `;
-}
-
-const cyclicSchemaErrorMessage = 'Cyclic schema detected without a resolvable GraphQL type name. ' +
-    "Register it with graphqlFieldOptions(schema, { typeName: '...' }) " +
-    "or add `__typename: z.literal('...')` to its shape so the builder can emit a named fragment.";
-
-type GraphqlFieldOptions = {
-    aliasFor?: string;
-    parameters?: Record<string, GraphqlValue>;
-    typeName?: string;
-};
 
 export type OperationOptions = {
     operationName?: string | undefined;
@@ -65,407 +27,65 @@ export type QueryBuilder = {
     buildMutation: (schema: QuerySchema, options?: OperationOptions) => string;
 };
 
-type FragmentDefinition = {
-    typeName: string;
-    body: string;
-    referencedVariables: Set<string>;
-};
-
-// StrictObjectSchema<FieldShape> as a Map key triggers TS2589 (excessively deep). The shape
-// of the schema is irrelevant for identity-based lookups, so we widen to FieldSchema here.
-type BuildContext = {
-    counts: Map<FieldSchema, number>;
-    nameForSchema: Map<FieldSchema, string>;
-    counterPerTypeName: Map<string, number>;
-    definitions: Map<string, FragmentDefinition>;
-};
-
-function unwrapFromArraySchema<SchemaType extends NonWrappedFieldSchema>(
-    predicate: (schema: NonWrappedFieldSchema) => schema is SchemaType,
-    schema: FieldArray
-): SchemaType | null {
-    const elementSchema = unwrapFieldSchema(schema._zod.def.element);
-    if (predicate(elementSchema)) {
-        return elementSchema;
+function withTrailingSpace(value: string): string {
+    if (value.length === 0) {
+        return value;
     }
-    return null;
+    return `${value} `;
 }
 
-function unwrapFromTupleSchema<SchemaType extends NonWrappedFieldSchema>(
-    predicate: (schema: NonWrappedFieldSchema) => schema is SchemaType,
-    schema: FieldSchemaTuple
-): SchemaType | null {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- ts-expect-error doesn’t work reliably here
-    // @ts-ignore -  Type instantiation is not infinite
-    const { items } = schema._zod.def;
-    const [firstElementSchema] = items;
-    const unwrappedElementSchema = unwrapFieldSchema(firstElementSchema);
-    if (predicate(unwrappedElementSchema)) {
-        return unwrappedElementSchema;
+function extractRootShape(schema: QuerySchema): FieldShape {
+    if (schema instanceof $ZodReadonly) {
+        return (schema._zod.def.innerType as StrictObjectSchema<FieldShape>)._zod.def.shape;
     }
-    return null;
+    return schema._zod.def.shape;
 }
 
-function getObjectSchema(schema: ObjectOrListSchema): StrictObjectSchema<FieldShape> | null {
-    if (isStrictObjectSchema(schema)) {
-        return schema;
-    }
-    if (schema instanceof $ZodArray) {
-        return unwrapFromArraySchema(isStrictObjectSchema, schema);
-    }
-    return unwrapFromTupleSchema(isStrictObjectSchema, schema);
+function createBuildContext(registry: FieldOptionsRegistry, rootShape: FieldShape): BuildContext {
+    return {
+        counts: collectSchemaReferences(registry, rootShape),
+        nameForSchema: new Map(),
+        counterPerTypeName: new Map(),
+        definitions: new Map()
+    };
 }
 
-function getUnionSchema(
-    schema: UnionOrListSchema
-): FragmentsSchema | null {
-    if (schema instanceof $ZodDiscriminatedUnion) {
-        return schema;
+function formatFragmentDefinitions(definitions: Map<string, FragmentDefinition>): string {
+    if (definitions.size === 0) {
+        return '';
     }
-    if (schema instanceof $ZodArray) {
-        return unwrapFromArraySchema(isFragmentsSchema, schema);
-    }
-    return unwrapFromTupleSchema(isFragmentsSchema, schema);
+    const sortedEntries = Array
+        .from(definitions.entries())
+        .toSorted(([nameA], [nameB]) => {
+            return nameA.localeCompare(nameB);
+        });
+    const formatted = sortedEntries.map(([name, definition]) => {
+        return `fragment ${name} on ${definition.typeName}${definition.body}`;
+    });
+    return ` ${formatted.join(' ')}`;
 }
 
-// eslint-disable-next-line max-statements -- each guard returns early; flattening would obscure intent
-function inferTypeNameFromShape(schema: StrictObjectSchema<FieldShape>): string | null {
-    const typenameField = schema._zod.def.shape.__typename;
-    if (typenameField === undefined) {
-        return null;
-    }
-    const unwrapped = unwrapFieldSchema(typenameField);
-    if (!(unwrapped instanceof $ZodLiteral)) {
-        return null;
-    }
-    const { values } = unwrapped._zod.def;
-    if (values.length !== 1) {
-        return null;
-    }
-    const [value] = values;
-    if (typeof value !== 'string' || !isValidGraphqlName(value)) {
-        return null;
-    }
-    return value;
+function buildDocument(
+    registry: FieldOptionsRegistry,
+    documentType: 'mutation' | 'query',
+    schema: QuerySchema,
+    options: OperationOptions
+): string {
+    const { variableDefinitions = {}, operationName = '' } = options;
+    const shape = extractRootShape(schema);
+    const context = createBuildContext(registry, shape);
+    const { bodyEntries, referencedVariables } = serializeRootShape(registry, shape, context);
+
+    ensureValidVariableCorrelations(variableDefinitions, referencedVariables);
+    const operationNameAndParams = withTrailingSpace(
+        `${operationName}${serializeVariableDefinitions(variableDefinitions)}`
+    );
+    const operationOutput = `${documentType} ${operationNameAndParams}{ ${bodyEntries.join(', ')} }`;
+    return operationOutput + formatFragmentDefinitions(context.definitions);
 }
 
-// eslint-disable-next-line max-statements -- each nested helper is small; flattening would lose grouping
 export function createQueryBuilder(): QueryBuilder {
-    const fieldOptionsRegistry = new WeakMap<FieldSchema, GraphqlFieldOptions>();
-
-    function getFieldOptionsForSchema(schema: FieldSchema): GraphqlFieldOptions {
-        const unwrappingResult = unwrapFieldSchemaChain(schema);
-        const queue: FieldSchema[] = [...unwrappingResult.wrapperElements, unwrappingResult.unwrappedSchema];
-
-        for (const currentSchema of queue) {
-            const fieldOptions = fieldOptionsRegistry.get(currentSchema);
-
-            if (fieldOptions !== undefined) {
-                return fieldOptions;
-            }
-        }
-
-        return {};
-    }
-
-    // eslint-disable-next-line complexity -- guard for conflict detection requires multiple conditions
-    function resolveTypeName(schema: StrictObjectSchema<FieldShape>): string | null {
-        const explicit = fieldOptionsRegistry.get(schema)?.typeName ?? null;
-        const inferred = inferTypeNameFromShape(schema);
-
-        if (explicit !== null && inferred !== null && explicit !== inferred) {
-            const prefix = `Conflicting GraphQL type name for schema: registered as "${explicit}" but `;
-            const suffix = `\`__typename\` literal is "${inferred}".`;
-            throw new Error(prefix + suffix);
-        }
-
-        return explicit ?? inferred;
-    }
-
-    function serializedFieldSelector(fieldName: string, fieldSchema: FieldSchema): NormalizedGraphqlValue {
-        const fieldOptions = getFieldOptionsForSchema(fieldSchema);
-        const { aliasFor, parameters } = fieldOptions;
-
-        const selectorName = aliasFor === undefined ? fieldName : `${fieldName}: ${aliasFor}`;
-
-        if (parameters !== undefined) {
-            const normalizedParameterList = normalizeParameterList(parameters);
-            return {
-                serializedValue: `${selectorName}${normalizedParameterList.serializedValue}`,
-                referencedVariables: normalizedParameterList.referencedVariables
-            };
-        }
-
-        return {
-            serializedValue: selectorName,
-            referencedVariables: new Set()
-        };
-    }
-
-    function collectSchemaReferences(rootShape: FieldShape): Map<FieldSchema, number> {
-        const counts = new Map<FieldSchema, number>();
-        const visiting = new Set<FieldSchema>();
-
-        function visitObject(objectSchema: StrictObjectSchema<FieldShape>): void {
-            counts.set(objectSchema, (counts.get(objectSchema) ?? 0) + 1);
-            if (visiting.has(objectSchema)) {
-                if (resolveTypeName(objectSchema) === null) {
-                    throw new Error(cyclicSchemaErrorMessage);
-                }
-                return;
-            }
-            visiting.add(objectSchema);
-            for (const childSchema of Object.values(objectSchema._zod.def.shape)) {
-                // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
-                visitField(childSchema);
-            }
-            visiting.delete(objectSchema);
-        }
-
-        // eslint-disable-next-line max-statements, complexity -- each branch mirrors the serializer
-        function visitField(fieldSchema: FieldSchema): void {
-            if (isCustomScalarSchema(fieldSchema)) {
-                return;
-            }
-            const unwrapped = unwrapFieldSchema(fieldSchema);
-            if (unwrapped instanceof $ZodUndefined) {
-                return;
-            }
-
-            if (isObjectOrListSchema(unwrapped)) {
-                const objectSchema = getObjectSchema(unwrapped);
-                if (objectSchema !== null) {
-                    visitObject(objectSchema);
-                    return;
-                }
-            }
-
-            if (isUnionOrListSchema(unwrapped)) {
-                const unionSchema = getUnionSchema(unwrapped);
-                if (unionSchema !== null) {
-                    for (const option of unionSchema._zod.def.options) {
-                        visitObject(option);
-                    }
-                }
-            }
-        }
-
-        for (const fieldSchema of Object.values(rootShape)) {
-            visitField(fieldSchema);
-        }
-
-        return counts;
-    }
-
-    // eslint-disable-next-line max-statements -- guard chain reads top-to-bottom; collapsing would obscure intent
-    function maybeAssignFragmentName(
-        objectSchema: StrictObjectSchema<FieldShape>,
-        ctx: BuildContext
-    ): string | null {
-        const existing = ctx.nameForSchema.get(objectSchema);
-        if (existing !== undefined) {
-            return existing;
-        }
-
-        const count = ctx.counts.get(objectSchema) ?? 0;
-        const minReuseForFragment = 2;
-        if (count < minReuseForFragment) {
-            return null;
-        }
-
-        const typeName = resolveTypeName(objectSchema);
-        if (typeName === null) {
-            return null;
-        }
-
-        const nextIndex = (ctx.counterPerTypeName.get(typeName) ?? 0) + 1;
-        ctx.counterPerTypeName.set(typeName, nextIndex);
-        const fragmentName = `${typeName}_${nextIndex}`;
-        ctx.nameForSchema.set(objectSchema, fragmentName);
-
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
-        const body = serializeObjectSchemaInline(objectSchema, ctx);
-        ctx.definitions.set(fragmentName, {
-            typeName,
-            body: body.serializedValue,
-            referencedVariables: body.referencedVariables
-        });
-
-        return fragmentName;
-    }
-
-    function serializeObjectSchemaInline(
-        objectSchema: FragmentUnionOptionSchema | StrictObjectSchema<FieldShape>,
-        ctx: BuildContext
-    ): NormalizedGraphqlValue {
-        const entries = Object.entries(objectSchema._zod.def.shape);
-        let referencedVariables = new Set<string>();
-        const serializedEntries: string[] = [];
-
-        for (const [fieldName, fieldSchema] of entries) {
-            // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursion
-            const serializedField = serializeFieldSchema(fieldName, fieldSchema, ctx);
-            referencedVariables = mergeVariables(referencedVariables, serializedField.referencedVariables);
-            serializedEntries.push(serializedField.serializedValue);
-        }
-
-        return {
-            serializedValue: ` { ${serializedEntries.join(', ')} }`,
-            referencedVariables
-        };
-    }
-
-    // eslint-disable-next-line max-statements, complexity -- no good idea how to refactor at the moment
-    function serializeFragments(
-        discriminatorMap: util.PropValues,
-        unionOptions: FragmentUnionOptionSchema[],
-        ctx: BuildContext
-    ): NormalizedGraphqlValue {
-        let referencedVariables = new Set<string>();
-        const serializedFragments: string[] = [];
-        const typeNameDiscriminator = discriminatorMap.__typename;
-        const discriminatorNames = Array.from(typeNameDiscriminator ?? []);
-
-        for (const [index, fragmentSchema] of unionOptions.entries()) {
-            const discriminatorName = discriminatorNames[index];
-            if (discriminatorName === undefined || discriminatorName === null) {
-                throw new Error(
-                    `Fragment name for index ${index} is undefined`
-                );
-            }
-
-            const assignedName = maybeAssignFragmentName(fragmentSchema, ctx);
-            if (assignedName === null) {
-                const serializedFragment = serializeObjectSchemaInline(fragmentSchema, ctx);
-                referencedVariables = mergeVariables(referencedVariables, serializedFragment.referencedVariables);
-                serializedFragments.push(`... on ${discriminatorName.toString()}${serializedFragment.serializedValue}`);
-            } else {
-                const definition = ctx.definitions.get(assignedName);
-                if (definition !== undefined) {
-                    referencedVariables = mergeVariables(referencedVariables, definition.referencedVariables);
-                }
-                serializedFragments.push(`...${assignedName}`);
-            }
-        }
-        return {
-            serializedValue: ` { ${serializedFragments.join(', ')} }`,
-            referencedVariables
-        };
-    }
-
-    function combineFieldSelectorAndFieldBody(
-        fieldSelector: NormalizedGraphqlValue,
-        fieldBody: NormalizedGraphqlValue
-    ): NormalizedGraphqlValue {
-        return {
-            serializedValue: `${fieldSelector.serializedValue}${fieldBody.serializedValue}`,
-            referencedVariables: mergeVariables(fieldSelector.referencedVariables, fieldBody.referencedVariables)
-        };
-    }
-
-    // eslint-disable-next-line max-statements, complexity -- no good idea how to refactor at the moment
-    function serializeFieldSchema(
-        fieldName: string,
-        fieldSchema: FieldSchema,
-        ctx: BuildContext
-    ): NormalizedGraphqlValue {
-        const fieldSelector = serializedFieldSelector(fieldName, fieldSchema);
-
-        if (isCustomScalarSchema(fieldSchema)) {
-            return fieldSelector;
-        }
-
-        const unwrappedSchema = unwrapFieldSchema(fieldSchema);
-
-        if (unwrappedSchema instanceof $ZodUndefined) {
-            return { serializedValue: '', referencedVariables: new Set() };
-        }
-
-        if (isObjectOrListSchema(unwrappedSchema)) {
-            const objectSchema = getObjectSchema(unwrappedSchema);
-
-            if (objectSchema !== null) {
-                const assignedName = maybeAssignFragmentName(objectSchema, ctx);
-                if (assignedName !== null) {
-                    const definition = ctx.definitions.get(assignedName);
-                    return combineFieldSelectorAndFieldBody(fieldSelector, {
-                        serializedValue: ` { ...${assignedName} }`,
-                        referencedVariables: definition?.referencedVariables ?? new Set()
-                    });
-                }
-                return combineFieldSelectorAndFieldBody(
-                    fieldSelector,
-                    serializeObjectSchemaInline(objectSchema, ctx)
-                );
-            }
-        }
-
-        if (isUnionOrListSchema(unwrappedSchema)) {
-            const unionSchema = getUnionSchema(unwrappedSchema);
-            if (unionSchema !== null) {
-                return combineFieldSelectorAndFieldBody(
-                    fieldSelector,
-                    serializeFragments(
-                        unionSchema._zod.propValues,
-                        unionSchema._zod.def.options,
-                        ctx
-                    )
-                );
-            }
-        }
-
-        return fieldSelector;
-    }
-
-    // eslint-disable-next-line max-statements, complexity -- no idea right now to make this smaller
-    function buildDocument(
-        documentType: 'mutation' | 'query',
-        schema: QuerySchema,
-        options: OperationOptions
-    ): string {
-        let referencedVariables = new Set<string>();
-        const { variableDefinitions = {}, operationName = '' } = options;
-        const bodyEntries: string[] = [];
-        const shape = schema instanceof $ZodReadonly ?
-            (schema._zod.def.innerType as StrictObjectSchema<FieldShape>)._zod.def.shape :
-            schema._zod.def.shape;
-
-        const ctx: BuildContext = {
-            counts: collectSchemaReferences(shape),
-            nameForSchema: new Map(),
-            counterPerTypeName: new Map(),
-            definitions: new Map()
-        };
-
-        for (const [fieldName, fieldSchema] of Object.entries(shape)) {
-            const serializedField = serializeFieldSchema(fieldName, fieldSchema, ctx);
-
-            if (serializedField.serializedValue.length > 0) {
-                bodyEntries.push(serializedField.serializedValue);
-            }
-            referencedVariables = mergeVariables(referencedVariables, serializedField.referencedVariables);
-        }
-
-        ensureValidVariableCorrelations(variableDefinitions, referencedVariables);
-        const operationNameAndParams = withTrailingSpace(
-            `${operationName}${serializeVariableDefinitions(variableDefinitions)}`
-        );
-
-        const operationOutput = `${documentType} ${operationNameAndParams}{ ${bodyEntries.join(', ')} }`;
-
-        if (ctx.definitions.size === 0) {
-            return operationOutput;
-        }
-
-        // eslint-disable-next-line unicorn/no-array-sort -- target is ES2022; Array#toSorted is unavailable
-        const sortedNames = Array.from(ctx.definitions.keys()).sort();
-        const fragmentOutputs = sortedNames.map((name) => {
-            const definition = ctx.definitions.get(name) as FragmentDefinition;
-            return `fragment ${name} on ${definition.typeName}${definition.body}`;
-        });
-
-        return `${operationOutput} ${fragmentOutputs.join(' ')}`;
-    }
+    const fieldOptionsRegistry: FieldOptionsRegistry = new WeakMap();
 
     return {
         registerFieldOptions<Schema extends FieldSchema>(
@@ -478,16 +98,15 @@ export function createQueryBuilder(): QueryBuilder {
                 );
             }
             fieldOptionsRegistry.set(schema, options);
-
             return schema;
         },
 
         buildQuery(schema, options = {}) {
-            return buildDocument('query', schema, options);
+            return buildDocument(fieldOptionsRegistry, 'query', schema, options);
         },
 
         buildMutation(schema, options = {}) {
-            return buildDocument('mutation', schema, options);
+            return buildDocument(fieldOptionsRegistry, 'mutation', schema, options);
         }
     };
 }

--- a/source/zod-graphql-query-builder/builder.ts
+++ b/source/zod-graphql-query-builder/builder.ts
@@ -2,6 +2,7 @@
 import {
     $ZodArray,
     $ZodDiscriminatedUnion,
+    $ZodLiteral,
     $ZodReadonly,
     $ZodUndefined,
     type util
@@ -26,6 +27,7 @@ import {
     unwrapFieldSchema,
     unwrapFieldSchemaChain
 } from './query-schema.js';
+import { isValidGraphqlName } from './values/name.js';
 import { normalizeParameterList } from './values/parameter-list.js';
 import type { GraphqlValue, NormalizedGraphqlValue } from './values/value.js';
 import { mergeVariables } from './values/variable-set.js';
@@ -39,9 +41,14 @@ function withTrailingSpace(value: string): string {
     return `${value} `;
 }
 
+const cyclicSchemaErrorMessage = 'Cyclic schema detected without a resolvable GraphQL type name. ' +
+    "Register it with graphqlFieldOptions(schema, { typeName: '...' }) " +
+    "or add `__typename: z.literal('...')` to its shape so the builder can emit a named fragment.";
+
 type GraphqlFieldOptions = {
     aliasFor?: string;
     parameters?: Record<string, GraphqlValue>;
+    typeName?: string;
 };
 
 export type OperationOptions = {
@@ -56,6 +63,21 @@ export type QueryBuilder = {
     ) => Schema;
     buildQuery: (schema: QuerySchema, options?: OperationOptions) => string;
     buildMutation: (schema: QuerySchema, options?: OperationOptions) => string;
+};
+
+type FragmentDefinition = {
+    typeName: string;
+    body: string;
+    referencedVariables: Set<string>;
+};
+
+// StrictObjectSchema<FieldShape> as a Map key triggers TS2589 (excessively deep). The shape
+// of the schema is irrelevant for identity-based lookups, so we widen to FieldSchema here.
+type BuildContext = {
+    counts: Map<FieldSchema, number>;
+    nameForSchema: Map<FieldSchema, string>;
+    counterPerTypeName: Map<string, number>;
+    definitions: Map<string, FragmentDefinition>;
 };
 
 function unwrapFromArraySchema<SchemaType extends NonWrappedFieldSchema>(
@@ -106,6 +128,28 @@ function getUnionSchema(
     return unwrapFromTupleSchema(isFragmentsSchema, schema);
 }
 
+// eslint-disable-next-line max-statements -- each guard returns early; flattening would obscure intent
+function inferTypeNameFromShape(schema: StrictObjectSchema<FieldShape>): string | null {
+    const typenameField = schema._zod.def.shape.__typename;
+    if (typenameField === undefined) {
+        return null;
+    }
+    const unwrapped = unwrapFieldSchema(typenameField);
+    if (!(unwrapped instanceof $ZodLiteral)) {
+        return null;
+    }
+    const { values } = unwrapped._zod.def;
+    if (values.length !== 1) {
+        return null;
+    }
+    const [value] = values;
+    if (typeof value !== 'string' || !isValidGraphqlName(value)) {
+        return null;
+    }
+    return value;
+}
+
+// eslint-disable-next-line max-statements -- each nested helper is small; flattening would lose grouping
 export function createQueryBuilder(): QueryBuilder {
     const fieldOptionsRegistry = new WeakMap<FieldSchema, GraphqlFieldOptions>();
 
@@ -122,6 +166,20 @@ export function createQueryBuilder(): QueryBuilder {
         }
 
         return {};
+    }
+
+    // eslint-disable-next-line complexity -- guard for conflict detection requires multiple conditions
+    function resolveTypeName(schema: StrictObjectSchema<FieldShape>): string | null {
+        const explicit = fieldOptionsRegistry.get(schema)?.typeName ?? null;
+        const inferred = inferTypeNameFromShape(schema);
+
+        if (explicit !== null && inferred !== null && explicit !== inferred) {
+            const prefix = `Conflicting GraphQL type name for schema: registered as "${explicit}" but `;
+            const suffix = `\`__typename\` literal is "${inferred}".`;
+            throw new Error(prefix + suffix);
+        }
+
+        return explicit ?? inferred;
     }
 
     function serializedFieldSelector(fieldName: string, fieldSchema: FieldSchema): NormalizedGraphqlValue {
@@ -144,8 +202,101 @@ export function createQueryBuilder(): QueryBuilder {
         };
     }
 
-    function serializeObjectSchema(
-        objectSchema: FragmentUnionOptionSchema | StrictObjectSchema<FieldShape>
+    function collectSchemaReferences(rootShape: FieldShape): Map<FieldSchema, number> {
+        const counts = new Map<FieldSchema, number>();
+        const visiting = new Set<FieldSchema>();
+
+        function visitObject(objectSchema: StrictObjectSchema<FieldShape>): void {
+            counts.set(objectSchema, (counts.get(objectSchema) ?? 0) + 1);
+            if (visiting.has(objectSchema)) {
+                if (resolveTypeName(objectSchema) === null) {
+                    throw new Error(cyclicSchemaErrorMessage);
+                }
+                return;
+            }
+            visiting.add(objectSchema);
+            for (const childSchema of Object.values(objectSchema._zod.def.shape)) {
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
+                visitField(childSchema);
+            }
+            visiting.delete(objectSchema);
+        }
+
+        // eslint-disable-next-line max-statements, complexity -- each branch mirrors the serializer
+        function visitField(fieldSchema: FieldSchema): void {
+            if (isCustomScalarSchema(fieldSchema)) {
+                return;
+            }
+            const unwrapped = unwrapFieldSchema(fieldSchema);
+            if (unwrapped instanceof $ZodUndefined) {
+                return;
+            }
+
+            if (isObjectOrListSchema(unwrapped)) {
+                const objectSchema = getObjectSchema(unwrapped);
+                if (objectSchema !== null) {
+                    visitObject(objectSchema);
+                    return;
+                }
+            }
+
+            if (isUnionOrListSchema(unwrapped)) {
+                const unionSchema = getUnionSchema(unwrapped);
+                if (unionSchema !== null) {
+                    for (const option of unionSchema._zod.def.options) {
+                        visitObject(option);
+                    }
+                }
+            }
+        }
+
+        for (const fieldSchema of Object.values(rootShape)) {
+            visitField(fieldSchema);
+        }
+
+        return counts;
+    }
+
+    // eslint-disable-next-line max-statements -- guard chain reads top-to-bottom; collapsing would obscure intent
+    function maybeAssignFragmentName(
+        objectSchema: StrictObjectSchema<FieldShape>,
+        ctx: BuildContext
+    ): string | null {
+        const existing = ctx.nameForSchema.get(objectSchema);
+        if (existing !== undefined) {
+            return existing;
+        }
+
+        const count = ctx.counts.get(objectSchema) ?? 0;
+        const minReuseForFragment = 2;
+        if (count < minReuseForFragment) {
+            return null;
+        }
+
+        const typeName = resolveTypeName(objectSchema);
+        if (typeName === null) {
+            return null;
+        }
+
+        const nextIndex = (ctx.counterPerTypeName.get(typeName) ?? 0) + 1;
+        ctx.counterPerTypeName.set(typeName, nextIndex);
+        const fragmentName = `${typeName}_${nextIndex}`;
+        ctx.nameForSchema.set(objectSchema, fragmentName);
+
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
+        const body = serializeObjectSchemaInline(objectSchema, ctx);
+        ctx.definitions.set(fragmentName, {
+            typeName,
+            body: body.serializedValue,
+            referencedVariables: body.referencedVariables
+        });
+
+        return fragmentName;
+    }
+
+    function serializeObjectSchemaInline(
+        objectSchema: FragmentUnionOptionSchema | StrictObjectSchema<FieldShape>,
+        ctx: BuildContext
     ): NormalizedGraphqlValue {
         const entries = Object.entries(objectSchema._zod.def.shape);
         let referencedVariables = new Set<string>();
@@ -153,7 +304,7 @@ export function createQueryBuilder(): QueryBuilder {
 
         for (const [fieldName, fieldSchema] of entries) {
             // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursion
-            const serializedField = serializeFieldSchema(fieldName, fieldSchema);
+            const serializedField = serializeFieldSchema(fieldName, fieldSchema, ctx);
             referencedVariables = mergeVariables(referencedVariables, serializedField.referencedVariables);
             serializedEntries.push(serializedField.serializedValue);
         }
@@ -164,26 +315,37 @@ export function createQueryBuilder(): QueryBuilder {
         };
     }
 
-    // eslint-disable-next-line max-statements -- no good idea how to refactor at the moment
+    // eslint-disable-next-line max-statements, complexity -- no good idea how to refactor at the moment
     function serializeFragments(
         discriminatorMap: util.PropValues,
-        unionOptions: FragmentUnionOptionSchema[]
+        unionOptions: FragmentUnionOptionSchema[],
+        ctx: BuildContext
     ): NormalizedGraphqlValue {
         let referencedVariables = new Set<string>();
         const serializedFragments: string[] = [];
         const typeNameDiscriminator = discriminatorMap.__typename;
-        const fragmentNames = Array.from(typeNameDiscriminator ?? []);
+        const discriminatorNames = Array.from(typeNameDiscriminator ?? []);
 
         for (const [index, fragmentSchema] of unionOptions.entries()) {
-            const fragmentName = fragmentNames[index];
-            if (fragmentName === undefined || fragmentName === null) {
+            const discriminatorName = discriminatorNames[index];
+            if (discriminatorName === undefined || discriminatorName === null) {
                 throw new Error(
                     `Fragment name for index ${index} is undefined`
                 );
             }
-            const serializedFragment = serializeObjectSchema(fragmentSchema);
-            referencedVariables = mergeVariables(referencedVariables, serializedFragment.referencedVariables);
-            serializedFragments.push(`... on ${fragmentName.toString()}${serializedFragment.serializedValue}`);
+
+            const assignedName = maybeAssignFragmentName(fragmentSchema, ctx);
+            if (assignedName === null) {
+                const serializedFragment = serializeObjectSchemaInline(fragmentSchema, ctx);
+                referencedVariables = mergeVariables(referencedVariables, serializedFragment.referencedVariables);
+                serializedFragments.push(`... on ${discriminatorName.toString()}${serializedFragment.serializedValue}`);
+            } else {
+                const definition = ctx.definitions.get(assignedName);
+                if (definition !== undefined) {
+                    referencedVariables = mergeVariables(referencedVariables, definition.referencedVariables);
+                }
+                serializedFragments.push(`...${assignedName}`);
+            }
         }
         return {
             serializedValue: ` { ${serializedFragments.join(', ')} }`,
@@ -204,7 +366,8 @@ export function createQueryBuilder(): QueryBuilder {
     // eslint-disable-next-line max-statements, complexity -- no good idea how to refactor at the moment
     function serializeFieldSchema(
         fieldName: string,
-        fieldSchema: FieldSchema
+        fieldSchema: FieldSchema,
+        ctx: BuildContext
     ): NormalizedGraphqlValue {
         const fieldSelector = serializedFieldSelector(fieldName, fieldSchema);
 
@@ -222,7 +385,18 @@ export function createQueryBuilder(): QueryBuilder {
             const objectSchema = getObjectSchema(unwrappedSchema);
 
             if (objectSchema !== null) {
-                return combineFieldSelectorAndFieldBody(fieldSelector, serializeObjectSchema(objectSchema));
+                const assignedName = maybeAssignFragmentName(objectSchema, ctx);
+                if (assignedName !== null) {
+                    const definition = ctx.definitions.get(assignedName);
+                    return combineFieldSelectorAndFieldBody(fieldSelector, {
+                        serializedValue: ` { ...${assignedName} }`,
+                        referencedVariables: definition?.referencedVariables ?? new Set()
+                    });
+                }
+                return combineFieldSelectorAndFieldBody(
+                    fieldSelector,
+                    serializeObjectSchemaInline(objectSchema, ctx)
+                );
             }
         }
 
@@ -233,7 +407,8 @@ export function createQueryBuilder(): QueryBuilder {
                     fieldSelector,
                     serializeFragments(
                         unionSchema._zod.propValues,
-                        unionSchema._zod.def.options
+                        unionSchema._zod.def.options,
+                        ctx
                     )
                 );
             }
@@ -242,7 +417,7 @@ export function createQueryBuilder(): QueryBuilder {
         return fieldSelector;
     }
 
-    // eslint-disable-next-line max-statements -- no idea right now to make this smaller
+    // eslint-disable-next-line max-statements, complexity -- no idea right now to make this smaller
     function buildDocument(
         documentType: 'mutation' | 'query',
         schema: QuerySchema,
@@ -255,16 +430,20 @@ export function createQueryBuilder(): QueryBuilder {
             (schema._zod.def.innerType as StrictObjectSchema<FieldShape>)._zod.def.shape :
             schema._zod.def.shape;
 
+        const ctx: BuildContext = {
+            counts: collectSchemaReferences(shape),
+            nameForSchema: new Map(),
+            counterPerTypeName: new Map(),
+            definitions: new Map()
+        };
+
         for (const [fieldName, fieldSchema] of Object.entries(shape)) {
-            const serializedField = serializeFieldSchema(fieldName, fieldSchema);
+            const serializedField = serializeFieldSchema(fieldName, fieldSchema, ctx);
 
             if (serializedField.serializedValue.length > 0) {
                 bodyEntries.push(serializedField.serializedValue);
             }
-            referencedVariables = new Set([
-                ...referencedVariables,
-                ...serializedField.referencedVariables
-            ]);
+            referencedVariables = mergeVariables(referencedVariables, serializedField.referencedVariables);
         }
 
         ensureValidVariableCorrelations(variableDefinitions, referencedVariables);
@@ -272,7 +451,20 @@ export function createQueryBuilder(): QueryBuilder {
             `${operationName}${serializeVariableDefinitions(variableDefinitions)}`
         );
 
-        return `${documentType} ${operationNameAndParams}{ ${bodyEntries.join(', ')} }`;
+        const operationOutput = `${documentType} ${operationNameAndParams}{ ${bodyEntries.join(', ')} }`;
+
+        if (ctx.definitions.size === 0) {
+            return operationOutput;
+        }
+
+        // eslint-disable-next-line unicorn/no-array-sort -- target is ES2022; Array#toSorted is unavailable
+        const sortedNames = Array.from(ctx.definitions.keys()).sort();
+        const fragmentOutputs = sortedNames.map((name) => {
+            const definition = ctx.definitions.get(name) as FragmentDefinition;
+            return `fragment ${name} on ${definition.typeName}${definition.body}`;
+        });
+
+        return `${operationOutput} ${fragmentOutputs.join(' ')}`;
     }
 
     return {
@@ -280,6 +472,11 @@ export function createQueryBuilder(): QueryBuilder {
             schema: Schema,
             options: GraphqlFieldOptions
         ): Schema {
+            if (options.typeName !== undefined && !isValidGraphqlName(options.typeName)) {
+                throw new Error(
+                    `Invalid GraphQL type name: "${options.typeName}". A type name must match /^[A-Z_a-z]\\w*$/.`
+                );
+            }
             fieldOptionsRegistry.set(schema, options);
 
             return schema;

--- a/source/zod-graphql-query-builder/readme.md
+++ b/source/zod-graphql-query-builder/readme.md
@@ -129,6 +129,84 @@ const query = buildGraphqlQuery(mySchema);
 query { foo { ... on A { __typename, valueA }, ... on B { __typename, valueB } } }
 ```
 
+### Named Fragments / Reusing Schemas
+
+When the same object schema reference is used in more than one place in a single operation, the builder
+automatically hoists its body into a named fragment to keep the produced query small. Two ways to opt in
+to this behavior — both rely on the builder being able to resolve a GraphQL type name for the schema.
+
+1. Register a `typeName` explicitly via `graphqlFieldOptions`, or
+2. Include `__typename: z.literal('TheTypeName')` in the strict-object's shape.
+
+If both are present and disagree the build throws. Schemas without a resolvable type name stay inlined at
+every use site exactly as before, so this feature is purely additive.
+
+**Input (explicit `typeName`):**
+
+```typescript
+import { buildGraphqlQuery, graphqlFieldOptions } from '@schema-hub/zod-graphql-query-builder';
+import { z } from 'zod';
+
+const userSchema = graphqlFieldOptions(
+    z.strictObject({ id: z.string(), name: z.string() }),
+    { typeName: 'User' }
+);
+const mySchema = z.strictObject({ me: userSchema, you: userSchema });
+const query = buildGraphqlQuery(mySchema);
+```
+
+**Built query:**
+
+```graphql
+query { me { ...User_1 }, you { ...User_1 } } fragment User_1 on User { id, name }
+```
+
+**Input (`typeName` inferred from `__typename` literal):**
+
+```typescript
+const userSchema = z.strictObject({
+    __typename: z.literal('User'),
+    id: z.string()
+});
+const mySchema = z.strictObject({ me: userSchema, you: userSchema });
+const query = buildGraphqlQuery(mySchema);
+```
+
+**Built query:**
+
+```graphql
+query { me { ...User_1 }, you { ...User_1 } } fragment User_1 on User { __typename, id }
+```
+
+Fragment names follow the pattern `<TypeName>_<index>`, where the index is a counter scoped to one
+`buildGraphqlQuery` / `buildGraphqlMutation` call. Two distinct schemas registered with the same `typeName`
+are disambiguated by the counter (`User_1`, `User_2`).
+
+**Cyclic schemas.** Self-referential schemas — which would otherwise be inexpressible as a finite inline
+selection — work as long as a type name is resolvable for them. The cyclic reference is emitted as a
+self-recursive fragment:
+
+```typescript
+type User = { id: string; friends: User[]; };
+const userSchema: z.ZodMiniType<User> = graphqlFieldOptions(
+    z.strictObject({
+        id: z.string(),
+        friends: z.array(z.lazy(() => userSchema))
+    }),
+    { typeName: 'User' }
+);
+const query = buildGraphqlQuery(z.strictObject({ me: userSchema }));
+```
+
+**Built query:**
+
+```graphql
+query { me { ...User_1 } } fragment User_1 on User { id, friends { ...User_1 } }
+```
+
+A cyclic schema without a resolvable type name is rejected at build time with an explicit error so the
+builder never enters an infinite recursion.
+
 ### Working with custom scalars
 
 **Input:**

--- a/source/zod-graphql-query-builder/serializer.ts
+++ b/source/zod-graphql-query-builder/serializer.ts
@@ -1,0 +1,501 @@
+/* eslint-disable no-underscore-dangle -- we need to access _zod */
+import {
+    $ZodArray,
+    $ZodDiscriminatedUnion,
+    $ZodUndefined,
+    type util
+} from 'zod/v4/core';
+import { isCustomScalarSchema } from './custom-scalar.js';
+import {
+    type FieldArray,
+    type FieldSchema,
+    type FieldSchemaTuple,
+    type FieldShape,
+    type FragmentsSchema,
+    type FragmentUnionOptionSchema,
+    isFragmentsSchema,
+    isObjectOrListSchema,
+    isStrictObjectSchema,
+    isUnionOrListSchema,
+    type NonWrappedFieldSchema,
+    type ObjectOrListSchema,
+    type StrictObjectSchema,
+    type UnionOrListSchema,
+    unwrapFieldSchema,
+    unwrapFieldSchemaChain
+} from './query-schema.js';
+import {
+    type FieldOptionsRegistry,
+    type GraphqlFieldOptions,
+    resolveTypeName
+} from './type-name.js';
+import { normalizeParameterList } from './values/parameter-list.js';
+import type { NormalizedGraphqlValue } from './values/value.js';
+import { mergeVariables } from './values/variable-set.js';
+
+export type { FieldOptionsRegistry, GraphqlFieldOptions } from './type-name.js';
+
+export type FragmentDefinition = {
+    typeName: string;
+    body: string;
+    referencedVariables: Set<string>;
+};
+
+// StrictObjectSchema<FieldShape> as a Map key triggers TS2589 (excessively deep). The shape
+// of the schema is irrelevant for identity-based lookups, so we widen to FieldSchema here.
+export type BuildContext = {
+    counts: Map<FieldSchema, number>;
+    nameForSchema: Map<FieldSchema, string>;
+    counterPerTypeName: Map<string, number>;
+    definitions: Map<string, FragmentDefinition>;
+};
+
+export type SerializedRootShape = {
+    bodyEntries: readonly string[];
+    referencedVariables: Set<string>;
+};
+
+type FragmentAllocation = {
+    fragmentName: string;
+    typeName: string;
+};
+
+type DiscriminatorValue = boolean | number | string;
+
+const minimumReuseCountForFragment = 2;
+
+const cyclicSchemaErrorMessage = 'Cyclic schema detected without a resolvable GraphQL type name. ' +
+    "Register it with graphqlFieldOptions(schema, { typeName: '...' }) " +
+    "or add `__typename: z.literal('...')` to its shape so the builder can emit a named fragment.";
+
+function unwrapFromArraySchema<SchemaType extends NonWrappedFieldSchema>(
+    predicate: (schema: NonWrappedFieldSchema) => schema is SchemaType,
+    schema: FieldArray
+): SchemaType | null {
+    const elementSchema = unwrapFieldSchema(schema._zod.def.element);
+    if (predicate(elementSchema)) {
+        return elementSchema;
+    }
+    return null;
+}
+
+function unwrapFromTupleSchema<SchemaType extends NonWrappedFieldSchema>(
+    predicate: (schema: NonWrappedFieldSchema) => schema is SchemaType,
+    schema: FieldSchemaTuple
+): SchemaType | null {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- ts-expect-error doesn’t work reliably here
+    // @ts-ignore -  Type instantiation is not infinite
+    const { items } = schema._zod.def;
+    const [firstElementSchema] = items;
+    const unwrappedElementSchema = unwrapFieldSchema(firstElementSchema);
+    if (predicate(unwrappedElementSchema)) {
+        return unwrappedElementSchema;
+    }
+    return null;
+}
+
+function getObjectSchema(schema: ObjectOrListSchema): StrictObjectSchema<FieldShape> | null {
+    if (isStrictObjectSchema(schema)) {
+        return schema;
+    }
+    if (schema instanceof $ZodArray) {
+        return unwrapFromArraySchema(isStrictObjectSchema, schema);
+    }
+    return unwrapFromTupleSchema(isStrictObjectSchema, schema);
+}
+
+function getUnionSchema(schema: UnionOrListSchema): FragmentsSchema | null {
+    if (schema instanceof $ZodDiscriminatedUnion) {
+        return schema;
+    }
+    if (schema instanceof $ZodArray) {
+        return unwrapFromArraySchema(isFragmentsSchema, schema);
+    }
+    return unwrapFromTupleSchema(isFragmentsSchema, schema);
+}
+
+function getFieldOptionsForSchema(
+    registry: FieldOptionsRegistry,
+    schema: FieldSchema
+): GraphqlFieldOptions {
+    const unwrappingResult = unwrapFieldSchemaChain(schema);
+    const queue: FieldSchema[] = [...unwrappingResult.wrapperElements, unwrappingResult.unwrappedSchema];
+    for (const currentSchema of queue) {
+        const fieldOptions = registry.get(currentSchema);
+        if (fieldOptions !== undefined) {
+            return fieldOptions;
+        }
+    }
+    return {};
+}
+
+function serializedFieldSelector(
+    registry: FieldOptionsRegistry,
+    fieldName: string,
+    fieldSchema: FieldSchema
+): NormalizedGraphqlValue {
+    const { aliasFor, parameters } = getFieldOptionsForSchema(registry, fieldSchema);
+    const selectorName = aliasFor === undefined ? fieldName : `${fieldName}: ${aliasFor}`;
+    if (parameters === undefined) {
+        return { serializedValue: selectorName, referencedVariables: new Set() };
+    }
+    const normalizedParameterList = normalizeParameterList(parameters);
+    return {
+        serializedValue: `${selectorName}${normalizedParameterList.serializedValue}`,
+        referencedVariables: normalizedParameterList.referencedVariables
+    };
+}
+
+function combineFieldSelectorAndFieldBody(
+    fieldSelector: NormalizedGraphqlValue,
+    fieldBody: NormalizedGraphqlValue
+): NormalizedGraphqlValue {
+    return {
+        serializedValue: `${fieldSelector.serializedValue}${fieldBody.serializedValue}`,
+        referencedVariables: mergeVariables(fieldSelector.referencedVariables, fieldBody.referencedVariables)
+    };
+}
+
+function getObjectSchemasFromList(
+    unwrapped: NonWrappedFieldSchema
+): readonly StrictObjectSchema<FieldShape>[] {
+    if (!isObjectOrListSchema(unwrapped)) {
+        return [];
+    }
+    const objectSchema = getObjectSchema(unwrapped);
+    return objectSchema === null ? [] : [objectSchema];
+}
+
+function getOptionsFromUnion(
+    unwrapped: NonWrappedFieldSchema
+): readonly FragmentUnionOptionSchema[] {
+    if (!isUnionOrListSchema(unwrapped)) {
+        return [];
+    }
+    const unionSchema = getUnionSchema(unwrapped);
+    return unionSchema === null ? [] : unionSchema._zod.def.options;
+}
+
+function getSchemasToVisit(
+    unwrapped: NonWrappedFieldSchema
+): readonly StrictObjectSchema<FieldShape>[] {
+    if (unwrapped instanceof $ZodUndefined) {
+        return [];
+    }
+    const objectSchemas = getObjectSchemasFromList(unwrapped);
+    if (objectSchemas.length > 0) {
+        return objectSchemas;
+    }
+    return getOptionsFromUnion(unwrapped);
+}
+
+function ensureCycleHasResolvableTypeName(
+    registry: FieldOptionsRegistry,
+    objectSchema: StrictObjectSchema<FieldShape>
+): void {
+    if (resolveTypeName(registry, objectSchema) !== null) {
+        return;
+    }
+    throw new Error(cyclicSchemaErrorMessage);
+}
+
+export function collectSchemaReferences(
+    registry: FieldOptionsRegistry,
+    rootShape: FieldShape
+): Map<FieldSchema, number> {
+    const counts = new Map<FieldSchema, number>();
+    const visiting = new Set<FieldSchema>();
+
+    function visitObject(objectSchema: StrictObjectSchema<FieldShape>): void {
+        counts.set(objectSchema, (counts.get(objectSchema) ?? 0) + 1);
+        if (visiting.has(objectSchema)) {
+            ensureCycleHasResolvableTypeName(registry, objectSchema);
+            return;
+        }
+        visiting.add(objectSchema);
+        for (const childSchema of Object.values(objectSchema._zod.def.shape)) {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
+            visitField(childSchema);
+        }
+        visiting.delete(objectSchema);
+    }
+
+    function visitField(fieldSchema: FieldSchema): void {
+        if (isCustomScalarSchema(fieldSchema)) {
+            return;
+        }
+        const unwrapped = unwrapFieldSchema(fieldSchema);
+        for (const objectSchema of getSchemasToVisit(unwrapped)) {
+            visitObject(objectSchema);
+        }
+    }
+
+    for (const fieldSchema of Object.values(rootShape)) {
+        visitField(fieldSchema);
+    }
+
+    return counts;
+}
+
+function allocateFragmentName(typeName: string, counterPerTypeName: Map<string, number>): string {
+    const nextIndex = (counterPerTypeName.get(typeName) ?? 0) + 1;
+    counterPerTypeName.set(typeName, nextIndex);
+    return `${typeName}_${nextIndex}`;
+}
+
+function tryAllocateFragmentForSchema(
+    registry: FieldOptionsRegistry,
+    objectSchema: StrictObjectSchema<FieldShape>,
+    context: BuildContext
+): FragmentAllocation | null {
+    const count = context.counts.get(objectSchema) ?? 0;
+    if (count < minimumReuseCountForFragment) {
+        return null;
+    }
+    const typeName = resolveTypeName(registry, objectSchema);
+    if (typeName === null) {
+        return null;
+    }
+    const fragmentName = allocateFragmentName(typeName, context.counterPerTypeName);
+    context.nameForSchema.set(objectSchema, fragmentName);
+    return { fragmentName, typeName };
+}
+
+function storeFragmentDefinition(
+    registry: FieldOptionsRegistry,
+    allocation: FragmentAllocation,
+    objectSchema: StrictObjectSchema<FieldShape>,
+    context: BuildContext
+): void {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion
+    const body = serializeObjectSchemaInline(registry, objectSchema, context);
+    context.definitions.set(allocation.fragmentName, {
+        typeName: allocation.typeName,
+        body: body.serializedValue,
+        referencedVariables: body.referencedVariables
+    });
+}
+
+function maybeAssignFragmentName(
+    registry: FieldOptionsRegistry,
+    objectSchema: StrictObjectSchema<FieldShape>,
+    context: BuildContext
+): string | null {
+    const existing = context.nameForSchema.get(objectSchema);
+    if (existing !== undefined) {
+        return existing;
+    }
+    const allocation = tryAllocateFragmentForSchema(registry, objectSchema, context);
+    if (allocation === null) {
+        return null;
+    }
+    storeFragmentDefinition(registry, allocation, objectSchema, context);
+    return allocation.fragmentName;
+}
+
+function serializeObjectSchemaInline(
+    registry: FieldOptionsRegistry,
+    objectSchema: FragmentUnionOptionSchema | StrictObjectSchema<FieldShape>,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    const entries = Object.entries(objectSchema._zod.def.shape);
+    let referencedVariables = new Set<string>();
+    const serializedEntries: string[] = [];
+    for (const [fieldName, fieldSchema] of entries) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- recursion
+        const serializedField = serializeFieldSchema(registry, fieldName, fieldSchema, context);
+        referencedVariables = mergeVariables(referencedVariables, serializedField.referencedVariables);
+        serializedEntries.push(serializedField.serializedValue);
+    }
+    return {
+        serializedValue: ` { ${serializedEntries.join(', ')} }`,
+        referencedVariables
+    };
+}
+
+function serializeFragmentReference(
+    assignedName: string,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    const definition = context.definitions.get(assignedName);
+    return {
+        serializedValue: `...${assignedName}`,
+        referencedVariables: definition?.referencedVariables ?? new Set()
+    };
+}
+
+function wrapFragmentReferenceAsBody(
+    assignedName: string,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    const reference = serializeFragmentReference(assignedName, context);
+    return {
+        serializedValue: ` { ${reference.serializedValue} }`,
+        referencedVariables: reference.referencedVariables
+    };
+}
+
+function lookupDiscriminatorName(
+    discriminatorNames: readonly unknown[],
+    index: number
+): DiscriminatorValue {
+    const value = discriminatorNames[index];
+    if (value === undefined || value === null) {
+        throw new Error(`Fragment name for index ${index} is undefined`);
+    }
+    return value as DiscriminatorValue;
+}
+
+function serializeInlineUnionOption(
+    registry: FieldOptionsRegistry,
+    discriminatorName: DiscriminatorValue,
+    fragmentSchema: FragmentUnionOptionSchema,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    const serializedFragment = serializeObjectSchemaInline(registry, fragmentSchema, context);
+    return {
+        serializedValue: `... on ${discriminatorName.toString()}${serializedFragment.serializedValue}`,
+        referencedVariables: serializedFragment.referencedVariables
+    };
+}
+
+function serializeFragmentUnionOption(
+    registry: FieldOptionsRegistry,
+    discriminatorName: DiscriminatorValue,
+    fragmentSchema: FragmentUnionOptionSchema,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    const assignedName = maybeAssignFragmentName(registry, fragmentSchema, context);
+    if (assignedName !== null) {
+        return serializeFragmentReference(assignedName, context);
+    }
+    return serializeInlineUnionOption(registry, discriminatorName, fragmentSchema, context);
+}
+
+function serializeFragments(
+    registry: FieldOptionsRegistry,
+    discriminatorMap: util.PropValues,
+    unionOptions: readonly FragmentUnionOptionSchema[],
+    context: BuildContext
+): NormalizedGraphqlValue {
+    let referencedVariables = new Set<string>();
+    const serializedFragments: string[] = [];
+    const discriminatorNames = Array.from(discriminatorMap.__typename ?? []);
+    for (const [index, fragmentSchema] of unionOptions.entries()) {
+        const discriminatorName = lookupDiscriminatorName(discriminatorNames, index);
+        const optionResult = serializeFragmentUnionOption(registry, discriminatorName, fragmentSchema, context);
+        referencedVariables = mergeVariables(referencedVariables, optionResult.referencedVariables);
+        serializedFragments.push(optionResult.serializedValue);
+    }
+    return {
+        serializedValue: ` { ${serializedFragments.join(', ')} }`,
+        referencedVariables
+    };
+}
+
+function serializeObjectField(
+    registry: FieldOptionsRegistry,
+    fieldSelector: NormalizedGraphqlValue,
+    objectSchema: StrictObjectSchema<FieldShape>,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    const assignedName = maybeAssignFragmentName(registry, objectSchema, context);
+    if (assignedName !== null) {
+        return combineFieldSelectorAndFieldBody(
+            fieldSelector,
+            wrapFragmentReferenceAsBody(assignedName, context)
+        );
+    }
+    return combineFieldSelectorAndFieldBody(
+        fieldSelector,
+        serializeObjectSchemaInline(registry, objectSchema, context)
+    );
+}
+
+function serializeUnionField(
+    registry: FieldOptionsRegistry,
+    fieldSelector: NormalizedGraphqlValue,
+    unionSchema: FragmentsSchema,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    return combineFieldSelectorAndFieldBody(
+        fieldSelector,
+        serializeFragments(registry, unionSchema._zod.propValues, unionSchema._zod.def.options, context)
+    );
+}
+
+function trySerializeObjectField(
+    registry: FieldOptionsRegistry,
+    fieldSelector: NormalizedGraphqlValue,
+    unwrapped: NonWrappedFieldSchema,
+    context: BuildContext
+): NormalizedGraphqlValue | null {
+    if (!isObjectOrListSchema(unwrapped)) {
+        return null;
+    }
+    const objectSchema = getObjectSchema(unwrapped);
+    if (objectSchema === null) {
+        return null;
+    }
+    return serializeObjectField(registry, fieldSelector, objectSchema, context);
+}
+
+function trySerializeUnionField(
+    registry: FieldOptionsRegistry,
+    fieldSelector: NormalizedGraphqlValue,
+    unwrapped: NonWrappedFieldSchema,
+    context: BuildContext
+): NormalizedGraphqlValue | null {
+    if (!isUnionOrListSchema(unwrapped)) {
+        return null;
+    }
+    const unionSchema = getUnionSchema(unwrapped);
+    if (unionSchema === null) {
+        return null;
+    }
+    return serializeUnionField(registry, fieldSelector, unionSchema, context);
+}
+
+function serializeUnwrappedFieldBody(
+    registry: FieldOptionsRegistry,
+    fieldSelector: NormalizedGraphqlValue,
+    unwrapped: NonWrappedFieldSchema,
+    context: BuildContext
+): NormalizedGraphqlValue | null {
+    if (unwrapped instanceof $ZodUndefined) {
+        return { serializedValue: '', referencedVariables: new Set() };
+    }
+    return trySerializeObjectField(registry, fieldSelector, unwrapped, context) ??
+        trySerializeUnionField(registry, fieldSelector, unwrapped, context);
+}
+
+function serializeFieldSchema(
+    registry: FieldOptionsRegistry,
+    fieldName: string,
+    fieldSchema: FieldSchema,
+    context: BuildContext
+): NormalizedGraphqlValue {
+    const fieldSelector = serializedFieldSelector(registry, fieldName, fieldSchema);
+    if (isCustomScalarSchema(fieldSchema)) {
+        return fieldSelector;
+    }
+    const unwrapped = unwrapFieldSchema(fieldSchema);
+    return serializeUnwrappedFieldBody(registry, fieldSelector, unwrapped, context) ?? fieldSelector;
+}
+
+export function serializeRootShape(
+    registry: FieldOptionsRegistry,
+    rootShape: FieldShape,
+    context: BuildContext
+): SerializedRootShape {
+    let referencedVariables = new Set<string>();
+    const bodyEntries: string[] = [];
+    for (const [fieldName, fieldSchema] of Object.entries(rootShape)) {
+        const serializedField = serializeFieldSchema(registry, fieldName, fieldSchema, context);
+        if (serializedField.serializedValue.length > 0) {
+            bodyEntries.push(serializedField.serializedValue);
+        }
+        referencedVariables = mergeVariables(referencedVariables, serializedField.referencedVariables);
+    }
+    return { bodyEntries, referencedVariables };
+}

--- a/source/zod-graphql-query-builder/type-name.ts
+++ b/source/zod-graphql-query-builder/type-name.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-underscore-dangle -- we need to access _zod */
+import { $ZodLiteral } from 'zod/v4/core';
+import {
+    type FieldSchema,
+    type FieldShape,
+    type StrictObjectSchema,
+    unwrapFieldSchema
+} from './query-schema.js';
+import { isValidGraphqlName } from './values/name.js';
+import type { GraphqlValue } from './values/value.js';
+
+export type GraphqlFieldOptions = {
+    aliasFor?: string;
+    parameters?: Record<string, GraphqlValue>;
+    typeName?: string;
+};
+
+export type FieldOptionsRegistry = WeakMap<FieldSchema, GraphqlFieldOptions>;
+
+function extractLiteralStringValue(schema: FieldSchema): string | null {
+    const unwrapped = unwrapFieldSchema(schema);
+    if (!(unwrapped instanceof $ZodLiteral)) {
+        return null;
+    }
+    const { values } = unwrapped._zod.def;
+    if (values.length !== 1) {
+        return null;
+    }
+    const [value] = values;
+    if (typeof value !== 'string') {
+        return null;
+    }
+    return value;
+}
+
+function inferTypeNameFromShape(schema: StrictObjectSchema<FieldShape>): string | null {
+    const typenameField = schema._zod.def.shape.__typename;
+    if (typenameField === undefined) {
+        return null;
+    }
+    const value = extractLiteralStringValue(typenameField);
+    if (value === null || !isValidGraphqlName(value)) {
+        return null;
+    }
+    return value;
+}
+
+function assertNoTypeNameConflict(explicit: string | null, inferred: string | null): void {
+    if (explicit === null || inferred === null || explicit === inferred) {
+        return;
+    }
+    const prefix = `Conflicting GraphQL type name for schema: registered as "${explicit}" but `;
+    const suffix = `\`__typename\` literal is "${inferred}".`;
+    throw new Error(prefix + suffix);
+}
+
+export function resolveTypeName(
+    registry: FieldOptionsRegistry,
+    schema: StrictObjectSchema<FieldShape>
+): string | null {
+    const explicit = registry.get(schema)?.typeName ?? null;
+    const inferred = inferTypeNameFromShape(schema);
+    assertNoTypeNameConflict(explicit, inferred);
+    return explicit ?? inferred;
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES2022",
+        "target": "ES2023",
         "module": "node16",
         "moduleResolution": "node16",
         "resolveJsonModule": true,


### PR DESCRIPTION
When the same zod object schema reference is used in more than one place in a single document and a GraphQL type name can be resolved for it (via graphqlFieldOptions({ typeName }) or a `__typename: z.literal(...)` in the shape), the builder now hoists its body into a `fragment <TypeName>_<n> on <TypeName> { ... }` definition and emits `...<TypeName>_<n>` at each use site. Single-use schemas and schemas without a resolvable type name still inline as before, so the change is purely additive for existing callers.

As a side effect, self-referential schemas (e.g. `z.lazy(() => self)`) now work via self-recursive fragments instead of infinite-looping. Cycles encountered without a resolvable type name are rejected at build time with a targeted error message.