### PR TITLE
Emit query output in deterministic alphabetical order

### DIFF
--- a/source/zod-graphql-query-builder/builder-basic-operations.test.ts
+++ b/source/zod-graphql-query-builder/builder-basic-operations.test.ts
@@ -140,7 +140,7 @@ import { variablePlaceholder } from './values/variable-placeholder.js';
             buildSchema() {
                 return z.strictObject({ foo: z.string(), bar: z.number() });
             },
-            expectedQuery: `${operationType} { foo, bar }`
+            expectedQuery: `${operationType} { bar, foo }`
         })
     );
 

--- a/source/zod-graphql-query-builder/builder-field-types.test.ts
+++ b/source/zod-graphql-query-builder/builder-field-types.test.ts
@@ -164,7 +164,7 @@ import { createCustomScalarSchema } from './custom-scalar.js';
                     });
                 return schema;
             },
-            expectedQuery: `${operationType} { foo, bar }`
+            expectedQuery: `${operationType} { bar, foo }`
         })
     );
 

--- a/source/zod-graphql-query-builder/builder-fragment-hoisting.test.ts
+++ b/source/zod-graphql-query-builder/builder-fragment-hoisting.test.ts
@@ -189,8 +189,8 @@ import { variablePlaceholder } from './values/variable-placeholder.js';
             },
             expectedQuery: oneLine`
                 ${operationType} { me { ...User_1 }, you { ...User_1 } }
-                fragment Address_1 on Address { street, city }
-                fragment User_1 on User { id, address { ...Address_1 } }
+                fragment Address_1 on Address { city, street }
+                fragment User_1 on User { address { ...Address_1 }, id }
             `
         })
     );
@@ -212,7 +212,7 @@ import { variablePlaceholder } from './values/variable-placeholder.js';
             operationOptions: { variableDefinitions: { $size: 'Int!' } },
             expectedQuery: oneLine`
                 ${operationType} ($size: Int!) { me { ...User_1 }, you { ...User_1 } }
-                fragment User_1 on User { id, avatar(size: $size) }
+                fragment User_1 on User { avatar(size: $size), id }
             `
         })
     );
@@ -294,7 +294,7 @@ import { variablePlaceholder } from './values/variable-placeholder.js';
                 const userSchema = builder.registerFieldOptions(baseUserSchema, { typeName: 'User' });
                 return z.strictObject({ me: userSchema });
             },
-            expectedQuery: `${operationType} { me { ...User_1 } } fragment User_1 on User { id, friends { ...User_1 } }`
+            expectedQuery: `${operationType} { me { ...User_1 } } fragment User_1 on User { friends { ...User_1 }, id }`
         })
     );
 

--- a/source/zod-graphql-query-builder/readme.md
+++ b/source/zod-graphql-query-builder/readme.md
@@ -101,7 +101,7 @@ const query = buildGraphqlQuery(mySchema, { variableDefinitions: { $var: 'String
 **Built query:**
 
 ```graphql
-query ($var: String!) { foo(anyParameterAssignedToPlainValue: "plain-string", anyParameterAssignedToEnumValue: foo, anyParameterReferencingAVariable: $var) }
+query ($var: String!) { foo(anyParameterAssignedToEnumValue: foo, anyParameterAssignedToPlainValue: "plain-string", anyParameterReferencingAVariable: $var) }
 ```
 
 ### Defining Fragments
@@ -201,7 +201,7 @@ const query = buildGraphqlQuery(z.strictObject({ me: userSchema }));
 **Built query:**
 
 ```graphql
-query { me { ...User_1 } } fragment User_1 on User { id, friends { ...User_1 } }
+query { me { ...User_1 } } fragment User_1 on User { friends { ...User_1 }, id }
 ```
 
 A cyclic schema without a resolvable type name is rejected at build time with an explicit error so the
@@ -303,5 +303,5 @@ const mutation = buildGraphqlMutation(mySchema, { variableDefinitions: { $var: '
 **Built mutation:**
 
 ```graphql
-mutation ($var: String!) { foo(anyParameterAssignedToPlainValue: "plain-string", anyParameterAssignedToEnumValue: foo, anyParameterReferencingAVariable: $var) }
+mutation ($var: String!) { foo(anyParameterAssignedToEnumValue: foo, anyParameterAssignedToPlainValue: "plain-string", anyParameterReferencingAVariable: $var) }
 ```

--- a/source/zod-graphql-query-builder/serializer.ts
+++ b/source/zod-graphql-query-builder/serializer.ts
@@ -284,7 +284,11 @@ function serializeObjectSchemaInline(
     objectSchema: FragmentUnionOptionSchema | StrictObjectSchema<FieldShape>,
     context: BuildContext
 ): NormalizedGraphqlValue {
-    const entries = Object.entries(objectSchema._zod.def.shape);
+    const entries = Object
+        .entries(objectSchema._zod.def.shape)
+        .toSorted(([nameA], [nameB]) => {
+            return nameA.localeCompare(nameB);
+        });
     let referencedVariables = new Set<string>();
     const serializedEntries: string[] = [];
     for (const [fieldName, fieldSchema] of entries) {
@@ -367,8 +371,13 @@ function serializeFragments(
     let referencedVariables = new Set<string>();
     const serializedFragments: string[] = [];
     const discriminatorNames = Array.from(discriminatorMap.__typename ?? []);
-    for (const [index, fragmentSchema] of unionOptions.entries()) {
-        const discriminatorName = lookupDiscriminatorName(discriminatorNames, index);
+    const pairedOptions = unionOptions.map((fragmentSchema, index) => {
+        return { discriminatorName: lookupDiscriminatorName(discriminatorNames, index), fragmentSchema };
+    });
+    const sortedOptions = pairedOptions.toSorted((optionA, optionB) => {
+        return optionA.discriminatorName.toString().localeCompare(optionB.discriminatorName.toString());
+    });
+    for (const { discriminatorName, fragmentSchema } of sortedOptions) {
         const optionResult = serializeFragmentUnionOption(registry, discriminatorName, fragmentSchema, context);
         referencedVariables = mergeVariables(referencedVariables, optionResult.referencedVariables);
         serializedFragments.push(optionResult.serializedValue);
@@ -476,7 +485,10 @@ export function serializeRootShape(
 ): SerializedRootShape {
     let referencedVariables = new Set<string>();
     const bodyEntries: string[] = [];
-    for (const [fieldName, fieldSchema] of Object.entries(rootShape)) {
+    const sortedEntries = Object.entries(rootShape).toSorted(([nameA], [nameB]) => {
+        return nameA.localeCompare(nameB);
+    });
+    for (const [fieldName, fieldSchema] of sortedEntries) {
         const serializedField = serializeFieldSchema(registry, fieldName, fieldSchema, context);
         if (serializedField.serializedValue.length > 0) {
             bodyEntries.push(serializedField.serializedValue);

--- a/source/zod-graphql-query-builder/values/parameter-list.test.ts
+++ b/source/zod-graphql-query-builder/values/parameter-list.test.ts
@@ -22,7 +22,7 @@ test('normalizes one parameter correctly', () => {
 test('normalizes multiple parameters correctly', () => {
     const result = normalizeParameterList({ foo: 'bar', bar: true });
     assert.deepStrictEqual(result, {
-        serializedValue: '(foo: "bar", bar: true)',
+        serializedValue: '(bar: true, foo: "bar")',
         referencedVariables: new Set()
     });
 });
@@ -33,7 +33,7 @@ test('normalizes multiple parameters with multiple variable placeholders correct
         bar: { baz: variablePlaceholder('$baz') }
     });
     assert.deepStrictEqual(result, {
-        serializedValue: '(foo: $foo, bar: {baz: $baz})',
+        serializedValue: '(bar: {baz: $baz}, foo: $foo)',
         referencedVariables: new Set(['$foo', '$baz'])
     });
 });

--- a/source/zod-graphql-query-builder/values/parameter-list.ts
+++ b/source/zod-graphql-query-builder/values/parameter-list.ts
@@ -6,7 +6,13 @@ export function normalizeParameterList(parameters: Record<string, GraphqlValue>)
     let referencedVariables = new Set<string>();
     const serializedParameters: string[] = [];
 
-    for (const [parameterName, parameterValue] of Object.entries(parameters)) {
+    const sortedEntries = Object
+        .entries(parameters)
+        .toSorted(([nameA], [nameB]) => {
+            return nameA.localeCompare(nameB);
+        });
+
+    for (const [parameterName, parameterValue] of sortedEntries) {
         if (!isValidGraphqlName(parameterName)) {
             throw new Error(`Parameter name "${parameterName}" is not a valid GraphQL parameter name`);
         }

--- a/source/zod-graphql-query-builder/values/value.test.ts
+++ b/source/zod-graphql-query-builder/values/value.test.ts
@@ -103,7 +103,7 @@ test('normalizes an array of variable placeholders correctly', () => {
 test('normalizes an object of primitives correctly', () => {
     const result = normalizeGraphqlValue({ foo: 'bar', bar: 1, qux: null });
     assert.deepStrictEqual(result, {
-        serializedValue: '{foo: "bar", bar: 1, qux: null}',
+        serializedValue: '{bar: 1, foo: "bar", qux: null}',
         referencedVariables: new Set()
     });
 });
@@ -131,7 +131,7 @@ test('normalizes a nested object with multiple variable placeholders correctly',
         bar: [[variablePlaceholder('$baz')], null]
     });
     assert.deepStrictEqual(result, {
-        serializedValue: '{foo: $bar, bar: [[$baz], null]}',
+        serializedValue: '{bar: [[$baz], null], foo: $bar}',
         referencedVariables: new Set(['$bar', '$baz'])
     });
 });

--- a/source/zod-graphql-query-builder/values/value.ts
+++ b/source/zod-graphql-query-builder/values/value.ts
@@ -37,7 +37,13 @@ function normalizeObjectValue(value: GraphqlObjectValue): NormalizedGraphqlValue
     let referencedVariables = new Set<string>();
     const serializedFields: string[] = [];
 
-    for (const [fieldName, fieldValue] of Object.entries(value)) {
+    const sortedEntries = Object
+        .entries(value)
+        .toSorted(([nameA], [nameB]) => {
+            return nameA.localeCompare(nameB);
+        });
+
+    for (const [fieldName, fieldValue] of sortedEntries) {
         if (!isValidGraphqlName(fieldName)) {
             throw new Error(`Field name "${fieldName}" is not a valid GraphQL field name`);
         }

--- a/source/zod-graphql-query-builder/variable-definition.test.ts
+++ b/source/zod-graphql-query-builder/variable-definition.test.ts
@@ -32,5 +32,5 @@ test('serializes one variable definition correctly', () => {
 
 test('serializes multiple variable definitions correctly', () => {
     const result = serializeVariableDefinitions({ $foo: 'bar', $bar: '[String!]!' });
-    assert.strictEqual(result, '($foo: bar, $bar: [String!]!)');
+    assert.strictEqual(result, '($bar: [String!]!, $foo: bar)');
 });

--- a/source/zod-graphql-query-builder/variable-definition.ts
+++ b/source/zod-graphql-query-builder/variable-definition.ts
@@ -29,7 +29,10 @@ export function serializeVariableDefinitions(definitions: VariableDefinitions): 
     }
 
     entries.forEach(ensureValidVariableDefinition);
-    const serializedEntries = entries.map(serializeVariableDefinitionPair);
+    const sortedEntries = entries.toSorted(([nameA], [nameB]) => {
+        return nameA.localeCompare(nameB);
+    });
+    const serializedEntries = sortedEntries.map(serializeVariableDefinitionPair);
 
     return `(${serializedEntries.join(', ')})`;
 }


### PR DESCRIPTION
Sort selection-set fields, field arguments, input object keys, variable definitions, and union fragment options so the same logical query produces the same query string regardless of declaration order. This improves persisted-query cache hit rates.