### PR TITLE
Surface structured GraphQL errors with extensions

### DIFF
--- a/source/zod-graphql-client/client.test.ts
+++ b/source/zod-graphql-client/client.test.ts
@@ -383,7 +383,7 @@ test('query() returns a graphql failure when response contains errors', async ()
         errorDetails: {
             message: 'GraphQL response contains errors',
             type: 'graphql',
-            errors: ['foo']
+            errors: [{ message: 'foo' }]
         }
     });
 });
@@ -581,7 +581,11 @@ test('query() with persistedQueries surfaces unrelated GraphQL errors without re
     assert.strictEqual(post.callCount, 1);
     assert.deepStrictEqual(result, {
         success: false,
-        errorDetails: { type: 'graphql', message: 'GraphQL response contains errors', errors: ['real failure'] }
+        errorDetails: {
+            type: 'graphql',
+            message: 'GraphQL response contains errors',
+            errors: [{ message: 'real failure' }]
+        }
     });
 });
 
@@ -629,7 +633,7 @@ test('query() with persistedQueries does not retry past one attempt on persisten
         errorDetails: {
             type: 'graphql',
             message: 'GraphQL response contains errors',
-            errors: ['PersistedQueryNotFound']
+            errors: [{ message: 'PersistedQueryNotFound' }]
         }
     });
 });

--- a/source/zod-graphql-client/entry-point.ts
+++ b/source/zod-graphql-client/entry-point.ts
@@ -24,7 +24,7 @@ export type {
 } from './define-variables.js';
 export { defineVariables } from './define-variables.js';
 export type { GraphqlTypeInferenceError } from './infer-graphql-type.js';
-export type { OperationErrorDetails } from './operation-error.js';
+export type { GraphqlError, OperationErrorDetails } from './operation-error.js';
 export { GraphqlOperationError } from './operation-error.js';
 export type { OperationHandle, OperationKind, ValuesOfOperationHandle } from './operation-handle.js';
 export { defineMutation, defineQuery } from './operation-handle.js';

--- a/source/zod-graphql-client/graphql-error.test.ts
+++ b/source/zod-graphql-client/graphql-error.test.ts
@@ -1,7 +1,7 @@
 import { test } from '@sondr3/minitest';
 import assert from 'node:assert';
 import { safeParse } from '../zod-error-formatter/formatter.js';
-import { formatAllErrors, graphqlErrorSchema } from './graphql-error.js';
+import { graphqlErrorSchema } from './graphql-error.js';
 
 test('graphqlErrorSchema: validation fails when a non-object is given', () => {
     const result = safeParse(graphqlErrorSchema, '');
@@ -110,6 +110,12 @@ test('graphqlErrorSchema: validation fails when a locations item has additional 
     assert.deepStrictEqual(result.error.issues, ['at locations[0]: unexpected additional property: "foo"']);
 });
 
+test('graphqlErrorSchema: validation fails when extensions is not an object', () => {
+    const result = safeParse(graphqlErrorSchema, { message: '', extensions: 'foo' });
+    assert.strictEqual(result.success, false);
+    assert.deepStrictEqual(result.error.issues, ['at extensions: expected record, but got string']);
+});
+
 test('graphqlErrorSchema: validation succeeds when locations is an empty array', () => {
     const result = safeParse(graphqlErrorSchema, { message: '', locations: [] });
     assert.strictEqual(result.success, true);
@@ -141,41 +147,31 @@ test('graphqlErrorSchema: validation succeeds when additional properties are giv
     assert.deepStrictEqual(result.data, { message: '' });
 });
 
+test('graphqlErrorSchema: validation succeeds when extensions is an empty object', () => {
+    const result = safeParse(graphqlErrorSchema, { message: '', extensions: {} });
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(result.data, { message: '', extensions: {} });
+});
+
+test('graphqlErrorSchema: validation succeeds and preserves arbitrary extension values', () => {
+    const result = safeParse(graphqlErrorSchema, {
+        message: '',
+        extensions: { code: 'BAD_USER_INPUT', details: { field: 'email' }, count: 3 }
+    });
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(result.data, {
+        message: '',
+        extensions: { code: 'BAD_USER_INPUT', details: { field: 'email' }, count: 3 }
+    });
+});
+
 test('graphqlErrorSchema: validation succeeds when a full error is given', () => {
     const result = safeParse(graphqlErrorSchema, {
         message: 'the-message',
         foo: 'bar',
         path: ['a', 'b', 1],
-        locations: [{ column: 1, line: 2 }, { line: 3, column: 4 }]
+        locations: [{ column: 1, line: 2 }, { line: 3, column: 4 }],
+        extensions: { code: 'INTERNAL_ERROR' }
     });
     assert.strictEqual(result.success, true);
-});
-
-test('formatAllErrors(): formats errors without path and locations', () => {
-    const formattedErrors = formatAllErrors([{ message: 'Foo' }]);
-    assert.deepStrictEqual(formattedErrors, ['Foo']);
-});
-
-test('formatAllErrors(): formats errors without path and locations is empty', () => {
-    const formattedErrors = formatAllErrors([{ message: 'Foo', locations: [] }]);
-    assert.deepStrictEqual(formattedErrors, ['Foo']);
-});
-
-test('formatAllErrors(): formats errors with path but without locations', () => {
-    const formattedErrors = formatAllErrors([{ message: 'Foo', path: ['bar'] }]);
-    assert.deepStrictEqual(formattedErrors, ['Error at bar - Foo']);
-});
-
-test('formatAllErrors(): formats errors with locations but without path', () => {
-    const formattedErrors = formatAllErrors([{ message: 'Foo', locations: [{ line: 1, column: 2 }] }]);
-    assert.deepStrictEqual(formattedErrors, ['Error at 1:2 - Foo']);
-});
-
-test('formatAllErrors(): formats errors with path and locations', () => {
-    const formattedErrors = formatAllErrors([{
-        message: 'Foo',
-        path: ['bar', 'baz'],
-        locations: [{ line: 1, column: 2 }]
-    }]);
-    assert.deepStrictEqual(formattedErrors, ['Error at bar.baz:1:2 - Foo']);
 });

--- a/source/zod-graphql-client/graphql-error.ts
+++ b/source/zod-graphql-client/graphql-error.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod/v4-mini';
-import { mapTuple, type NonEmptyArray } from '../tuple/non-empty-array.js';
 
 const locationSchema = z
     .strictObject({
@@ -7,60 +6,14 @@ const locationSchema = z
         column: z.number().check(z.int(), z.positive())
     });
 
-type Location = z.infer<typeof locationSchema>;
-
 const pathSegmentSchema = z.union([z.string(), z.number()]);
-
-type PathSegment = z.infer<typeof pathSegmentSchema>;
 
 export const graphqlErrorSchema = z
     .object({
         message: z.string(),
         locations: z.optional(z.array(locationSchema)),
-        path: z.optional(z.array(pathSegmentSchema))
+        path: z.optional(z.array(pathSegmentSchema)),
+        extensions: z.optional(z.record(z.string(), z.unknown()))
     });
 
 export type GraphqlError = z.infer<typeof graphqlErrorSchema>;
-
-function formatLocations(locations?: Location[]): string {
-    if (locations === undefined) {
-        return '';
-    }
-
-    const [firstLocation] = locations;
-    if (firstLocation === undefined) {
-        return '';
-    }
-    return `${firstLocation.line}:${firstLocation.column}`;
-}
-
-function formatPath(path?: PathSegment[]): string {
-    return path === undefined ? '' : path.join('.');
-}
-
-function formatPrefix(error: GraphqlError): string {
-    const formattedPath = formatPath(error.path);
-    const formattedLocation = formatLocations(error.locations);
-
-    if (formattedPath.length > 0 && formattedLocation.length > 0) {
-        return `Error at ${formattedPath}:${formattedLocation} - `;
-    }
-    if (formattedPath.length > 0) {
-        return `Error at ${formattedPath} - `;
-    }
-    if (formattedLocation.length > 0) {
-        return `Error at ${formattedLocation} - `;
-    }
-    return '';
-}
-
-function formatGraphqlError(error: GraphqlError): string {
-    const prefix = formatPrefix(error);
-    return `${prefix}${error.message}`;
-}
-
-export function formatAllErrors(
-    errors: NonEmptyArray<GraphqlError>
-): NonEmptyArray<string> {
-    return mapTuple(errors, formatGraphqlError);
-}

--- a/source/zod-graphql-client/graphql-response.test.ts
+++ b/source/zod-graphql-client/graphql-response.test.ts
@@ -35,14 +35,28 @@ test('returns a failure result when an errors item is invalid', () => {
     });
 });
 
-test('returns a failure result with the formatted errors when there is at least one error', () => {
+test('returns a failure result with the structured errors when there is at least one error', () => {
     const result = parseGraphqlResponse({ errors: [{ message: 'foo', path: ['bar'] }] });
     assert.deepStrictEqual(result, {
         success: false,
         errorDetails: {
             type: 'graphql',
             message: 'GraphQL response contains errors',
-            errors: ['Error at bar - foo']
+            errors: [{ message: 'foo', path: ['bar'] }]
+        }
+    });
+});
+
+test('returns a failure result preserving extensions on each error', () => {
+    const result = parseGraphqlResponse({
+        errors: [{ message: 'forbidden', extensions: { code: 'FORBIDDEN', traceId: 'abc' } }]
+    });
+    assert.deepStrictEqual(result, {
+        success: false,
+        errorDetails: {
+            type: 'graphql',
+            message: 'GraphQL response contains errors',
+            errors: [{ message: 'forbidden', extensions: { code: 'FORBIDDEN', traceId: 'abc' } }]
         }
     });
 });

--- a/source/zod-graphql-client/graphql-response.ts
+++ b/source/zod-graphql-client/graphql-response.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod/v4';
 import { isNonEmptyArray } from '../tuple/non-empty-array.js';
 import { safeParse } from '../zod-error-formatter/formatter.js';
-import { formatAllErrors, graphqlErrorSchema } from './graphql-error.js';
+import { graphqlErrorSchema } from './graphql-error.js';
 import type { OperationResultForType } from './operation-result.js';
 
 const graphqlResponseSchema = z
@@ -23,7 +23,7 @@ export function parseGraphqlResponse(responseBody: unknown): OperationResultForT
                 errorDetails: {
                     type: 'graphql',
                     message: 'GraphQL response contains errors',
-                    errors: formatAllErrors(errors)
+                    errors
                 }
             };
         }

--- a/source/zod-graphql-client/operation-error.ts
+++ b/source/zod-graphql-client/operation-error.ts
@@ -1,4 +1,7 @@
 import type { NonEmptyArray } from '../tuple/non-empty-array.js';
+import type { GraphqlError } from './graphql-error.js';
+
+export type { GraphqlError } from './graphql-error.js';
 
 type BaseError = {
     message: string;
@@ -6,7 +9,7 @@ type BaseError = {
 
 type GraphqlResponseError = BaseError & {
     type: 'graphql';
-    errors: NonEmptyArray<string>;
+    errors: NonEmptyArray<GraphqlError>;
 };
 
 type ServerError = BaseError & {


### PR DESCRIPTION
Previously, individual GraphQL errors from a 200 response were flattened to pre-formatted strings, dropping the structured path and stripping extensions from the schema entirely. Callers had no way to branch on extensions.code or rebuild the path.

errorDetails.errors is now NonEmptyArray<GraphqlError> carrying message, locations, path, and extensions (typed as an opaque Record<string, unknown> per the GraphQL spec).