### PR TITLE
Cover nested input object variables in client tests

### DIFF
--- a/source/zod-graphql-client/client.test.ts
+++ b/source/zod-graphql-client/client.test.ts
@@ -245,6 +245,103 @@ test('query() with a handle returns a validation failure when values don’t mat
     });
 });
 
+const nestedFilterSchema = z.strictObject({
+    q: z.string(),
+    pagination: z.strictObject({ limit: z.int(), offset: z.int() })
+});
+const variablesForNestedInput = defineVariables({
+    filter: variable('FilterInput!', nestedFilterSchema)
+});
+const queryWithNestedInputSchema = z.strictObject({
+    foo: graphqlFieldOptions(z.string(), { parameters: { filter: variablePlaceholder('$filter') } })
+});
+const queryWithNestedInput = defineQuery({
+    variables: variablesForNestedInput,
+    schema: queryWithNestedInputSchema
+});
+
+test('query() sends a nested input object as a variable value', async () => {
+    const post = createFakeKyMethod();
+    const client = clientFactory({ post, options: { endpoint: 'http://example/the-endpoint' } });
+    await client.query(queryWithNestedInput, {
+        filter: { q: 'hello', pagination: { limit: 10, offset: 20 } }
+    });
+
+    assert.strictEqual(post.callCount, 1);
+    assert.deepStrictEqual(post.firstCall.args, ['http://example/the-endpoint', {
+        headers: {},
+        json: {
+            operationName: undefined,
+            query: 'query ($filter: FilterInput!) { foo(filter: $filter) }',
+            variables: { filter: { q: 'hello', pagination: { limit: 10, offset: 20 } } }
+        },
+        retry: 0,
+        throwHttpErrors: false,
+        timeout: 10_000
+    }]);
+});
+
+test('query() with a nested input variable reports validation issues with a nested path', async () => {
+    const post = createFakeKyMethod();
+    const client = clientFactory({ post, options: { endpoint: 'http://example/the-endpoint' } });
+    const result = await client.query(queryWithNestedInput, {
+        filter: {
+            q: 'hello',
+            pagination: { limit: 'ten' as unknown as number, offset: 20 }
+        }
+    });
+
+    assert.strictEqual(post.callCount, 0);
+    assert.deepStrictEqual(result, {
+        success: false,
+        errorDetails: {
+            type: 'validation',
+            message: 'GraphQL variable values don’t match the expected schema',
+            issues: ['at filter.pagination.limit: expected number, but got string']
+        }
+    });
+});
+
+const variablesForListInput = defineVariables({
+    filters: variable('[FilterInput!]!', z.array(nestedFilterSchema))
+});
+const queryWithListInputSchema = z.strictObject({
+    foo: graphqlFieldOptions(z.string(), { parameters: { filters: variablePlaceholder('$filters') } })
+});
+const queryWithListInput = defineQuery({
+    variables: variablesForListInput,
+    schema: queryWithListInputSchema
+});
+
+test('query() sends a list of input objects as a variable value', async () => {
+    const post = createFakeKyMethod();
+    const client = clientFactory({ post, options: { endpoint: 'http://example/the-endpoint' } });
+    await client.query(queryWithListInput, {
+        filters: [
+            { q: 'hello', pagination: { limit: 10, offset: 0 } },
+            { q: 'world', pagination: { limit: 5, offset: 10 } }
+        ]
+    });
+
+    assert.strictEqual(post.callCount, 1);
+    assert.deepStrictEqual(post.firstCall.args, ['http://example/the-endpoint', {
+        headers: {},
+        json: {
+            operationName: undefined,
+            query: 'query ($filters: [FilterInput!]!) { foo(filters: $filters) }',
+            variables: {
+                filters: [
+                    { q: 'hello', pagination: { limit: 10, offset: 0 } },
+                    { q: 'world', pagination: { limit: 5, offset: 10 } }
+                ]
+            }
+        },
+        retry: 0,
+        throwHttpErrors: false,
+        timeout: 10_000
+    }]);
+});
+
 test('query() returns a network failure result when the request times out', async () => {
     const timeoutError = new TimeoutError({} as unknown as Request);
     const post = createFakeKyMethod({ error: timeoutError });


### PR DESCRIPTION
Pin client-level behavior for variable values that aren't scalars: a nested input object, a deeply nested validation error path, and a list of input objects. No production change, the building blocks were already exercised individually; this locks in the end-to-end glue through the client.