### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,63 +1,66 @@
 {
-    "name": "schema-hub",
-    "version": "0.0.0-dev",
-    "type": "module",
-    "scripts": {
-        "compile": "tsc --build",
-        "format:check": "dprint check --list-different",
-        "format:fix": "dprint fmt",
-        "eslint": "eslint . --cache --cache-location './target/.eslintcache' --cache-strategy content --max-warnings 0",
-        "eslint:fix": "npm run eslint -- --fix",
-        "lint": "npm run eslint && npm run format:check",
-        "lint:fix": "npm run eslint:fix && npm run format:fix",
-        "test": "npm run test:unit:with-coverage && npm run test:types && npm run test:integration",
-        "pretest:unit": "tsc -b source/tsconfig.unit-tests.json",
-        "test:unit": "mt target/build/source",
-        "test:unit:with-coverage": "c8 npm run test:unit",
-        "test:types": "tstyche",
-        "pretest:integration": "tsc -b integration-tests/tsconfig.json",
-        "test:integration": "mt target/build/integration-tests"
-    },
-    "author": "Mathias Schreck <schreck.mathias@gmail.com>",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+ssh://git@github.com/enormora/schema-hub.git"
-    },
-    "dependencies": {
-        "graphql": "16.14.2",
-        "ky": "2.0.2",
-        "tslib": "2.8.1"
-    },
-    "devDependencies": {
-        "@ben_12/eslint-plugin-dprint": "1.3.3",
-        "@dprint/json": "0.20.0",
-        "@dprint/markdown": "0.18.0",
-        "@dprint/typescript": "0.95.15",
-        "@enormora/eslint-config-base": "0.0.23",
-        "@enormora/eslint-config-node": "0.0.20",
-        "@enormora/eslint-config-typescript": "0.0.26",
-        "@packtory/cli": "0.0.33",
-        "@sondr3/minitest": "0.1.2",
-        "@types/common-tags": "1.8.4",
-        "@types/node": "24.13.2",
-        "@types/sinon": "21.0.1",
-        "c8": "11.0.0",
-        "common-tags": "1.8.2",
-        "dprint": "0.54.0",
-        "eslint": "9.39.4",
-        "sinon": "22.0.0",
-        "tstyche": "7.2.1",
-        "typescript": "6.0.3",
-        "zod": "4.2.1"
-    },
-    "engines": {
-        "node": "^24 || ^26"
-    },
-    "peerDependencies": {
-        "zod": "^4.0.5"
-    },
-    "overrides": {
-        "yargs": "18.0.0"
-    }
+  "name": "schema-hub",
+  "version": "0.0.0-dev",
+  "bugs": {
+    "url": "https://github.com/enormora/schema-hub/issues"
+  },
+  "type": "module",
+  "scripts": {
+    "compile": "tsc --build",
+    "format:check": "dprint check --list-different",
+    "format:fix": "dprint fmt",
+    "eslint": "eslint . --cache --cache-location './target/.eslintcache' --cache-strategy content --max-warnings 0",
+    "eslint:fix": "npm run eslint -- --fix",
+    "lint": "npm run eslint && npm run format:check",
+    "lint:fix": "npm run eslint:fix && npm run format:fix",
+    "test": "npm run test:unit:with-coverage && npm run test:types && npm run test:integration",
+    "pretest:unit": "tsc -b source/tsconfig.unit-tests.json",
+    "test:unit": "mt target/build/source",
+    "test:unit:with-coverage": "c8 npm run test:unit",
+    "test:types": "tstyche",
+    "pretest:integration": "tsc -b integration-tests/tsconfig.json",
+    "test:integration": "mt target/build/integration-tests"
+  },
+  "author": "Mathias Schreck <schreck.mathias@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/enormora/schema-hub.git"
+  },
+  "dependencies": {
+    "graphql": "16.14.2",
+    "ky": "2.0.2",
+    "tslib": "2.8.1"
+  },
+  "devDependencies": {
+    "@ben_12/eslint-plugin-dprint": "1.3.3",
+    "@dprint/json": "0.20.0",
+    "@dprint/markdown": "0.18.0",
+    "@dprint/typescript": "0.95.15",
+    "@enormora/eslint-config-base": "0.0.23",
+    "@enormora/eslint-config-node": "0.0.20",
+    "@enormora/eslint-config-typescript": "0.0.26",
+    "@packtory/cli": "0.0.33",
+    "@sondr3/minitest": "0.1.2",
+    "@types/common-tags": "1.8.4",
+    "@types/node": "24.13.2",
+    "@types/sinon": "21.0.1",
+    "c8": "11.0.0",
+    "common-tags": "1.8.2",
+    "dprint": "0.54.0",
+    "eslint": "9.39.4",
+    "sinon": "22.0.0",
+    "tstyche": "7.2.1",
+    "typescript": "6.0.3",
+    "zod": "4.2.1"
+  },
+  "engines": {
+    "node": "^24 || ^26"
+  },
+  "peerDependencies": {
+    "zod": "^4.0.5"
+  },
+  "overrides": {
+    "yargs": "18.0.0"
+  }
 }


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.