### PR TITLE
Improve `z.union` formatting for nested literal object branches

### DIFF
--- a/integration-tests/zod-error-formatter/union.test.ts
+++ b/integration-tests/zod-error-formatter/union.test.ts
@@ -3,6 +3,8 @@ import { test } from '@sondr3/minitest';
 import { z } from 'zod/v4-mini';
 import { safeParse } from '../../source/zod-error-formatter/formatter.ts';
 
+type VersionProvider = () => string;
+
 test('formats messages for invalid union schemas with primitives correctly', function () {
     const schema = z.union([ z.string(), z.number() ]);
     const result = safeParse(schema, true);
@@ -60,5 +62,69 @@ test('formats messages missing properties of union schemas within object correct
     assert.strictEqual(result.success, false);
     assert.deepStrictEqual(result.error.issues, [
         'at foo: missing property'
+    ]);
+});
+
+test('formats messages for nested literal object unions with the matching branch issues', function () {
+    const nonEmptyStringSchema = z.string().check(z.minLength(1));
+    const automaticVersioningSettingsSchema = z.readonly(
+        z.strictObject({
+            automatic: z.literal(true),
+            minimumVersion: z.optional(nonEmptyStringSchema)
+        })
+    );
+    const staticManualVersioningSettingsSchema = z.readonly(
+        z.strictObject({
+            automatic: z.literal(false),
+            version: nonEmptyStringSchema
+        })
+    );
+    const providerManualVersioningSettingsSchema = z.readonly(
+        z.strictObject({
+            automatic: z.literal(false),
+            provideVersion: z.custom<VersionProvider>(function (value) {
+                return typeof value === 'function';
+            })
+        })
+    );
+    const manualVersioningSettingsSchema = z.readonly(
+        z.union([ staticManualVersioningSettingsSchema, providerManualVersioningSettingsSchema ])
+    );
+    const versioningSettingsSchema = z.readonly(
+        z.union([ automaticVersioningSettingsSchema, manualVersioningSettingsSchema ])
+    );
+
+    const emptyManualResult = safeParse(versioningSettingsSchema, { automatic: false });
+    const invalidStaticManualResult = safeParse(versioningSettingsSchema, { automatic: false, version: '' });
+    const invalidProviderManualResult = safeParse(versioningSettingsSchema, {
+        automatic: false,
+        provideVersion: '1.0.0'
+    });
+    const invalidAutomaticResult = safeParse(versioningSettingsSchema, { automatic: true, minimumVersion: '' });
+    const invalidDiscriminatorResult = safeParse(versioningSettingsSchema, { automatic: 'maybe' });
+
+    assert.strictEqual(emptyManualResult.success, false);
+    assert.deepStrictEqual(emptyManualResult.error.issues, [
+        'no union alternative matched: alternative 1: at version: missing property; expected string | alternative 2: at provideVersion: Invalid input'
+    ]);
+
+    assert.strictEqual(invalidStaticManualResult.success, false);
+    assert.deepStrictEqual(invalidStaticManualResult.error.issues, [
+        'at version: string must contain at least 1 character'
+    ]);
+
+    assert.strictEqual(invalidProviderManualResult.success, false);
+    assert.deepStrictEqual(invalidProviderManualResult.error.issues, [
+        'at provideVersion: Invalid input'
+    ]);
+
+    assert.strictEqual(invalidAutomaticResult.success, false);
+    assert.deepStrictEqual(invalidAutomaticResult.error.issues, [
+        'at minimumVersion: string must contain at least 1 character'
+    ]);
+
+    assert.strictEqual(invalidDiscriminatorResult.success, false);
+    assert.deepStrictEqual(invalidDiscriminatorResult.error.issues, [
+        'at automatic: invalid value: expected one of true or false, but got string'
     ]);
 });

--- a/source/zod-error-formatter/issue-specific/boundary-issue.ts
+++ b/source/zod-error-formatter/issue-specific/boundary-issue.ts
@@ -15,10 +15,7 @@ const collectionTypes = new Set([ 'string', 'array', 'set' ]);
 const numericTypes = new Set([ 'bigint', 'number' ]);
 
 function inclusivePredicate(issue: BoundaryIssue, inclusiveVariant: string, nonInclusiveVariant: string): string {
-    if (issue.inclusive === true) {
-        return inclusiveVariant;
-    }
-    return nonInclusiveVariant;
+    return issue.inclusive === false ? nonInclusiveVariant : inclusiveVariant;
 }
 
 function formatPredicate(issue: BoundaryIssue, phrases: BoundaryPhrases): string {

--- a/source/zod-error-formatter/issue-specific/invalid-union-alternatives.test.ts
+++ b/source/zod-error-formatter/issue-specific/invalid-union-alternatives.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert';
+import { test } from '@sondr3/minitest';
+import type {
+    $ZodIssue,
+    $ZodIssueCustom,
+    $ZodIssueInvalidType,
+    $ZodIssueInvalidValue,
+    $ZodIssueUnrecognizedKeys,
+    util
+} from 'zod/v4/core';
+import {
+    allValuesArePrimitive,
+    collectInvalidValueIssues,
+    findInvalidValuePathCandidate,
+    isInvalidValueIssue,
+    isPrimitive,
+    isSamePath,
+    selectRelevantAlternatives
+} from './invalid-union-alternatives.ts';
+
+function invalidValue(path: PropertyKey[], values: util.Primitive[]): $ZodIssueInvalidValue {
+    return { code: 'invalid_value', path, message: '', input: undefined, values };
+}
+
+function invalidType(path: PropertyKey[], expected: $ZodIssueInvalidType['expected']): $ZodIssueInvalidType {
+    return { code: 'invalid_type', path, message: '', input: undefined, expected };
+}
+
+function customIssue(path: PropertyKey[]): $ZodIssueCustom {
+    return { code: 'custom', path, message: '', input: undefined };
+}
+
+function unrecognizedKeys(keys: string[]): $ZodIssueUnrecognizedKeys {
+    return { code: 'unrecognized_keys', path: [], message: '', input: {}, keys };
+}
+
+test('identifies invalid value issues', function () {
+    const issue = invalidValue([ 'kind' ], [ 'a' ]);
+    const otherIssue = invalidType([ 'kind' ], 'string');
+
+    assert.strictEqual(isInvalidValueIssue(issue), true);
+    assert.strictEqual(isInvalidValueIssue(otherIssue), false);
+});
+
+test('identifies primitive values', function () {
+    assert.strictEqual(isPrimitive('value'), true);
+    assert.strictEqual(isPrimitive(null), true);
+    assert.strictEqual(isPrimitive({}), false);
+});
+
+test('compares issue paths', function () {
+    assert.strictEqual(isSamePath([ 'a', 0 ], [ 'a', 0 ]), true);
+    assert.strictEqual(isSamePath([ 'a' ], [ 'a', 0 ]), false);
+    assert.strictEqual(isSamePath([ 'a', 1 ], [ 'a', 0 ]), false);
+});
+
+test('collects invalid value issues from alternatives', function () {
+    const first = invalidValue([ 'kind' ], [ 'a' ]);
+    const second = invalidValue([ 'mode' ], [ 'strict' ]);
+    const alternatives: readonly (readonly $ZodIssue[])[] = [
+        [ first, invalidType([ 'name' ], 'string') ],
+        [ second ]
+    ];
+
+    assert.deepStrictEqual(collectInvalidValueIssues(alternatives), [ first, second ]);
+});
+
+test('detects primitive values across invalid value issues', function () {
+    assert.strictEqual(allValuesArePrimitive([ invalidValue([ 'kind' ], [ 'a', 1 ]) ]), true);
+});
+
+test('finds a discriminator candidate when every alternative has only that invalid value path', function () {
+    const firstIssue = invalidValue([ 'kind' ], [ 'a' ]);
+    const secondIssue = invalidValue([ 'kind' ], [ 'b' ]);
+    const candidate = findInvalidValuePathCandidate([
+        [ firstIssue ],
+        [ secondIssue ]
+    ]);
+
+    assert.deepStrictEqual(candidate, { path: [ 'kind' ], issues: [ firstIssue, secondIssue ] });
+});
+
+test('finds a discriminator candidate when expected values repeat across richer alternatives', function () {
+    const automaticIssue = invalidValue([ 'automatic' ], [ true ]);
+    const staticManualIssue = invalidValue([ 'automatic' ], [ false ]);
+    const providerManualIssue = invalidValue([ 'automatic' ], [ false ]);
+    const candidate = findInvalidValuePathCandidate([
+        [ automaticIssue ],
+        [ staticManualIssue, invalidType([ 'version' ], 'string') ],
+        [ providerManualIssue, customIssue([ 'provideVersion' ]) ]
+    ]);
+
+    assert.deepStrictEqual(
+        candidate,
+        { path: [ 'automatic' ], issues: [ automaticIssue, staticManualIssue, providerManualIssue ] }
+    );
+});
+
+test('does not find a discriminator candidate when alternatives do not share a path', function () {
+    const candidate = findInvalidValuePathCandidate([
+        [ invalidValue([ 'kind' ], [ 'a' ]) ],
+        [ invalidType([ 'name' ], 'string') ]
+    ]);
+
+    assert.strictEqual(candidate, null);
+});
+
+test('selects alternatives that do not reject an already present invalid value path', function () {
+    const automaticAlternative = [ invalidValue([ 'automatic' ], [ true ]) ];
+    const manualAlternative = [ invalidType([ 'version' ], 'string') ];
+    const selected = selectRelevantAlternatives([ automaticAlternative, manualAlternative ], { automatic: false });
+
+    assert.deepStrictEqual(selected, [ manualAlternative ]);
+});
+
+test('keeps alternatives when an invalid value path is absent from the input', function () {
+    const automaticAlternative = [ invalidValue([ 'automatic' ], [ true ]) ];
+    const manualAlternative = [ invalidType([ 'version' ], 'string') ];
+    const alternatives = [ automaticAlternative, manualAlternative ];
+
+    assert.deepStrictEqual(selectRelevantAlternatives(alternatives, {}), alternatives);
+});
+
+test('selects alternatives that do not reject an unrecognized key', function () {
+    const staticAlternative = [ invalidType([ 'version' ], 'string') ];
+    const providerAlternative = [ customIssue([ 'provideVersion' ]), unrecognizedKeys([ 'version' ]) ];
+    const selected = selectRelevantAlternatives([ staticAlternative, providerAlternative ], { version: '' });
+
+    assert.deepStrictEqual(selected, [ staticAlternative ]);
+});
+
+test('selects through repeated unrecognized-key reductions when every selection matches', function () {
+    const staticAlternative = [ invalidType([ 'version' ], 'string') ];
+    const providerAlternative = [
+        customIssue([ 'provideVersion' ]),
+        unrecognizedKeys([ 'version', 'minimumVersion' ])
+    ];
+    const selected = selectRelevantAlternatives([ staticAlternative, providerAlternative ], { version: '' });
+
+    assert.deepStrictEqual(selected, [ staticAlternative ]);
+});
+
+test('keeps alternatives when unrecognized-key selections disagree', function () {
+    const staticAlternative = [ invalidType([ 'version' ], 'string'), unrecognizedKeys([ 'provideVersion' ]) ];
+    const providerAlternative = [
+        customIssue([ 'provideVersion' ]),
+        unrecognizedKeys([ 'version' ])
+    ];
+    const alternatives = [ staticAlternative, providerAlternative ];
+
+    assert.deepStrictEqual(selectRelevantAlternatives(alternatives, { version: '', provideVersion: '' }), alternatives);
+});
+
+test('keeps alternatives when unrecognized-key selections have different sizes', function () {
+    const firstAlternative = [ invalidType([ 'a' ], 'string') ];
+    const secondAlternative = [ invalidType([ 'b' ], 'number'), unrecognizedKeys([ 'y' ]) ];
+    const thirdAlternative = [ invalidType([ 'c' ], 'boolean'), unrecognizedKeys([ 'x', 'y' ]) ];
+    const alternatives = [ firstAlternative, secondAlternative, thirdAlternative ];
+
+    assert.deepStrictEqual(selectRelevantAlternatives(alternatives, { x: true, y: true }), alternatives);
+});

--- a/source/zod-error-formatter/issue-specific/invalid-union-alternatives.ts
+++ b/source/zod-error-formatter/issue-specific/invalid-union-alternatives.ts
@@ -1,0 +1,264 @@
+import type {
+    $ZodIssue,
+    $ZodIssueInvalidValue,
+    $ZodIssueUnrecognizedKeys,
+    util
+} from 'zod/v4/core';
+import { findValueByPath } from '../path.ts';
+
+export type AlternativeBucket = readonly $ZodIssue[];
+
+type Selection = {
+    readonly alternatives: readonly AlternativeBucket[];
+};
+
+export type InvalidValuePathCandidate = {
+    readonly path: readonly PropertyKey[];
+    readonly issues: readonly $ZodIssueInvalidValue[];
+};
+
+export function isInvalidValueIssue(issue: $ZodIssue): issue is $ZodIssueInvalidValue {
+    return issue.code === 'invalid_value';
+}
+
+function isUnrecognizedKeysIssue(issue: $ZodIssue): issue is $ZodIssueUnrecognizedKeys {
+    return issue.code === 'unrecognized_keys';
+}
+
+export function isPrimitive(value: unknown): value is util.Primitive {
+    return [ 'string', 'number', 'symbol', 'bigint', 'boolean', 'undefined' ].includes(typeof value) || value === null;
+}
+
+export function isSamePath(pathA: readonly PropertyKey[], pathB: readonly PropertyKey[]): boolean {
+    if (pathA.length !== pathB.length) {
+        return false;
+    }
+
+    return pathA.every(function (element, index) {
+        return element === pathB[index];
+    });
+}
+
+function isSameAlternativeSet(selectionA: Selection, selectionB: Selection): boolean {
+    if (selectionA.alternatives.length !== selectionB.alternatives.length) {
+        return false;
+    }
+    return selectionA.alternatives.every(function (alternative, index) {
+        return alternative === selectionB.alternatives[index];
+    });
+}
+
+function getUniquePaths(issues: readonly $ZodIssueInvalidValue[]): readonly (readonly PropertyKey[])[] {
+    const paths: (readonly PropertyKey[])[] = [];
+
+    for (const issue of issues) {
+        if (
+            paths.every(function (path) {
+                return !isSamePath(path, issue.path);
+            })
+        ) {
+            paths.push(issue.path);
+        }
+    }
+
+    return paths;
+}
+
+export function collectInvalidValueIssues(
+    alternatives: readonly AlternativeBucket[]
+): readonly $ZodIssueInvalidValue[] {
+    return alternatives.flatMap(function (bucket) {
+        return bucket.filter(isInvalidValueIssue);
+    });
+}
+
+function findInvalidValueIssuesAtPath(
+    bucket: AlternativeBucket,
+    path: readonly PropertyKey[]
+): readonly $ZodIssueInvalidValue[] {
+    return bucket.filter(function (issue): issue is $ZodIssueInvalidValue {
+        return isInvalidValueIssue(issue) && isSamePath(issue.path, path);
+    });
+}
+
+export function allValuesArePrimitive(issues: readonly $ZodIssueInvalidValue[]): boolean {
+    return issues.every(function (issue) {
+        return issue.values.every(isPrimitive);
+    });
+}
+
+function hasRepeatedExpectedValue(issues: readonly $ZodIssueInvalidValue[]): boolean {
+    const expectedValues = issues.flatMap(function (issue) {
+        return issue.values;
+    });
+    const uniqueExpectedValues = new Set(expectedValues);
+    return uniqueExpectedValues.size < expectedValues.length;
+}
+
+function everyAlternativeHasOnlyInvalidValueAtPath(
+    alternatives: readonly AlternativeBucket[],
+    path: readonly PropertyKey[]
+): boolean {
+    return alternatives.every(function (bucket) {
+        return bucket.length === 1 && findInvalidValueIssuesAtPath(bucket, path).length === 1;
+    });
+}
+
+function collectIssuesAtPath(
+    alternatives: readonly AlternativeBucket[],
+    path: readonly PropertyKey[]
+): readonly $ZodIssueInvalidValue[] {
+    return alternatives.flatMap(function (bucket) {
+        return findInvalidValueIssuesAtPath(bucket, path);
+    });
+}
+
+function everyAlternativeHasIssueAtPath(
+    alternatives: readonly AlternativeBucket[],
+    path: readonly PropertyKey[]
+): boolean {
+    return alternatives.every(function (bucket) {
+        return findInvalidValueIssuesAtPath(bucket, path).length > 0;
+    });
+}
+
+function canCollapseInvalidValuePath(
+    alternatives: readonly AlternativeBucket[],
+    path: readonly PropertyKey[]
+): boolean {
+    const issuesAtPath = collectIssuesAtPath(alternatives, path);
+    const safelyRepresentsBranchChoice = everyAlternativeHasOnlyInvalidValueAtPath(alternatives, path)
+        || hasRepeatedExpectedValue(issuesAtPath);
+
+    return everyAlternativeHasIssueAtPath(alternatives, path) && safelyRepresentsBranchChoice;
+}
+
+export function findInvalidValuePathCandidate(
+    alternatives: readonly AlternativeBucket[]
+): InvalidValuePathCandidate | null {
+    const paths = getUniquePaths(collectInvalidValueIssues(alternatives));
+    const path = paths.find(function (candidatePath) {
+        return canCollapseInvalidValuePath(alternatives, candidatePath);
+    });
+
+    if (path === undefined) {
+        return null;
+    }
+
+    return { path, issues: collectIssuesAtPath(alternatives, path) };
+}
+
+function selectWithoutInvalidValuePath(
+    alternatives: readonly AlternativeBucket[],
+    path: readonly PropertyKey[]
+): Selection | null {
+    const alternativesWithIssue = alternatives.filter(function (bucket) {
+        return findInvalidValueIssuesAtPath(bucket, path).length > 0;
+    });
+    const alternativesWithoutIssue = alternatives.filter(function (bucket) {
+        return findInvalidValueIssuesAtPath(bucket, path).length === 0;
+    });
+    const issuesAtPath = alternativesWithIssue.flatMap(function (bucket) {
+        return findInvalidValueIssuesAtPath(bucket, path);
+    });
+
+    if (
+        alternativesWithIssue.length > 0 &&
+        alternativesWithoutIssue.length > 0 &&
+        allValuesArePrimitive(issuesAtPath)
+    ) {
+        return { alternatives: alternativesWithoutIssue };
+    }
+
+    return null;
+}
+
+function selectAlternativesWithoutInvalidValuePath(
+    alternatives: readonly AlternativeBucket[],
+    inputAtUnion: unknown
+): Selection | null {
+    const paths = getUniquePaths(collectInvalidValueIssues(alternatives));
+    const path = paths.find(function (candidatePath) {
+        return candidatePath.length > 0 && findValueByPath(inputAtUnion, candidatePath).found;
+    });
+
+    return path === undefined ? null : selectWithoutInvalidValuePath(alternatives, path);
+}
+
+function issueHasUnrecognizedKey(issue: $ZodIssue, key: string): boolean {
+    return isUnrecognizedKeysIssue(issue) && issue.keys.includes(key);
+}
+
+function bucketHasUnrecognizedKey(bucket: AlternativeBucket, key: string): boolean {
+    return bucket.some(function (issue) {
+        return issueHasUnrecognizedKey(issue, key);
+    });
+}
+
+function collectUnrecognizedKeys(alternatives: readonly AlternativeBucket[]): readonly string[] {
+    const keys = alternatives.flatMap(function (bucket) {
+        return bucket
+            .filter(isUnrecognizedKeysIssue)
+            .flatMap(function (issue) {
+                return issue.keys;
+            });
+    });
+
+    return Array.from(new Set(keys));
+}
+
+function selectWithoutUnrecognizedKey(alternatives: readonly AlternativeBucket[], key: string): Selection | null {
+    const alternativesWithKey = alternatives.filter(function (bucket) {
+        return bucketHasUnrecognizedKey(bucket, key);
+    });
+    const alternativesWithoutKey = alternatives.filter(function (bucket) {
+        return bucket.every(function (issue) {
+            return !issueHasUnrecognizedKey(issue, key);
+        });
+    });
+
+    if (alternativesWithKey.length > 0 && alternativesWithoutKey.length > 0) {
+        return { alternatives: alternativesWithoutKey };
+    }
+
+    return null;
+}
+
+function selectAlternativesWithoutUnrecognizedKey(
+    alternatives: readonly AlternativeBucket[]
+): Selection | null {
+    const selections = collectUnrecognizedKeys(alternatives)
+        .map(function (key) {
+            return selectWithoutUnrecognizedKey(alternatives, key);
+        })
+        .filter(function (selection): selection is Selection {
+            return selection !== null;
+        });
+
+    const [ firstSelection ] = selections;
+    const allSelectionsMatch = firstSelection !== undefined && selections.every(function (selection) {
+        return isSameAlternativeSet(selection, firstSelection);
+    });
+
+    return allSelectionsMatch ? firstSelection : null;
+}
+
+export function selectRelevantAlternatives(
+    alternatives: readonly AlternativeBucket[],
+    inputAtUnion: unknown
+): readonly AlternativeBucket[] {
+    let currentAlternatives = alternatives;
+
+    while (currentAlternatives.length > 1) {
+        const selection = selectAlternativesWithoutInvalidValuePath(currentAlternatives, inputAtUnion)
+            ?? selectAlternativesWithoutUnrecognizedKey(currentAlternatives);
+
+        if (selection === null || selection.alternatives.length === currentAlternatives.length) {
+            return currentAlternatives;
+        }
+
+        currentAlternatives = selection.alternatives;
+    }
+
+    return currentAlternatives;
+}

--- a/source/zod-error-formatter/issue-specific/invalid-union.test.ts
+++ b/source/zod-error-formatter/issue-specific/invalid-union.test.ts
@@ -433,9 +433,6 @@ test('factors out common issues and enumerates the rest when the reduced alterna
 });
 
 test('emits only the common issue when one alternative is fully described by the shared constraints', function () {
-    // alt 1 carries only the common issue, so fixing it alone makes alt 1 pass —
-    // reporting alt 2's extra requirement would mislead the user into thinking
-    // both must be addressed.
     const message = formatInvalidUnionIssueMessage(
         {
             code: 'invalid_union',
@@ -474,9 +471,6 @@ test('handles a single-alternative union as a regular collapse', function () {
 });
 
 test('does not expand a nested invalid_union when its alternative carries other sibling issues', function () {
-    // The bucket carries both a nested invalid_union and an unrelated invalid_type.
-    // Expansion would discard the sibling, so the formatter must keep the bucket
-    // intact and let formatIssue recurse into the nested union.
     const message = formatInvalidUnionIssueMessage(
         {
             code: 'invalid_union',

--- a/source/zod-error-formatter/issue-specific/invalid-union.ts
+++ b/source/zod-error-formatter/issue-specific/invalid-union.ts
@@ -7,10 +7,16 @@ import {
 } from 'zod/v4/core';
 import { formatOneOfList, isParsedType, type ListValue } from '../list.ts';
 import { findValueByPath, formatPath, isNonEmptyPath } from '../path.ts';
+import {
+    allValuesArePrimitive,
+    type AlternativeBucket,
+    findInvalidValuePathCandidate,
+    isPrimitive,
+    isSamePath,
+    selectRelevantAlternatives
+} from './invalid-union-alternatives.ts';
 
 type FormatChildIssue = (issue: $ZodIssue, input: unknown) => string;
-
-type AlternativeBucket = readonly $ZodIssue[];
 
 type SupportedIssueType = $ZodIssueInvalidType | $ZodIssueInvalidValue;
 
@@ -21,20 +27,6 @@ type CollapseCandidate = {
 
 function isSupportedIssue(issue: $ZodIssue): issue is SupportedIssueType {
     return issue.code === 'invalid_type' || issue.code === 'invalid_value';
-}
-
-function isPrimitive(value: unknown): value is util.Primitive {
-    return [ 'string', 'number', 'symbol', 'bigint', 'boolean', 'undefined' ].includes(typeof value) || value === null;
-}
-
-function isSamePath(pathA: readonly PropertyKey[], pathB: readonly PropertyKey[]): boolean {
-    if (pathA.length !== pathB.length) {
-        return false;
-    }
-
-    return pathA.every(function (element, index) {
-        return element === pathB[index];
-    });
 }
 
 function prependPath(path: readonly PropertyKey[], message: string): string {
@@ -176,6 +168,27 @@ function renderCollapsedMessage(candidate: CollapseCandidate, inputAtUnion: unkn
     return prependPath(candidate.commonPath, message);
 }
 
+function renderInvalidValuePathMessage(
+    issues: readonly $ZodIssueInvalidValue[],
+    path: readonly PropertyKey[],
+    inputAtUnion: unknown
+): string | null {
+    if (!allValuesArePrimitive(issues)) {
+        return null;
+    }
+    return renderCollapsedMessage({ commonPath: path, issues }, inputAtUnion);
+}
+
+function tryCollapseInvalidValuePath(
+    alternatives: readonly AlternativeBucket[],
+    inputAtUnion: unknown
+): string | null {
+    const candidate = findInvalidValuePathCandidate(alternatives);
+    return candidate === null
+        ? null
+        : renderInvalidValuePathMessage(candidate.issues, candidate.path, inputAtUnion);
+}
+
 function tryCollapseToOneOfMessage(
     alternatives: readonly AlternativeBucket[],
     inputAtUnion: unknown
@@ -299,6 +312,33 @@ function enumerateAlternatives(
     return `no union alternative matched: ${lines.join(' | ')}`;
 }
 
+function renderSingleAlternative(
+    alternative: AlternativeBucket,
+    inputAtUnion: unknown,
+    formatChildIssue: FormatChildIssue
+): string | null {
+    const rendered = alternative.map(function (issue) {
+        return formatChildIssue(issue, inputAtUnion);
+    });
+
+    if (rendered.length === 0) {
+        return null;
+    }
+
+    return rendered.join('; ');
+}
+
+function renderOnlyAlternative(
+    alternatives: readonly AlternativeBucket[],
+    inputAtUnion: unknown,
+    formatChildIssue: FormatChildIssue
+): string | null {
+    const [ onlyAlternative ] = alternatives;
+    return onlyAlternative !== undefined && alternatives.length === 1
+        ? renderSingleAlternative(onlyAlternative, inputAtUnion, formatChildIssue)
+        : null;
+}
+
 function joinWithCommon(commonRendered: readonly string[], rest: string): string {
     if (commonRendered.length === 0) {
         return rest;
@@ -307,13 +347,13 @@ function joinWithCommon(commonRendered: readonly string[], rest: string): string
 }
 
 // Factor out issues that appear (by rendered-message equality) in every
-// alternative — they are hard requirements of the union regardless of which
+// alternative because they are hard requirements of the union regardless of which
 // branch the user picks. After factoring, retry collapse on the reduced
 // alternatives so e.g. a discriminator field can OR-merge once shared
 // constraints have been lifted. Returns null only when there is genuinely
 // nothing reportable.
 // If any alternative is fully described by the common issues, fixing those
-// is sufficient — the union passes via that alternative. Listing the other
+// is sufficient because the union passes via that alternative. Listing the other
 // alternatives' extra constraints would be misleading. Also retries collapse
 // on the reduced alternatives so a discriminator field can OR-merge cleanly.
 function tryFactoredCollapse(
@@ -365,6 +405,16 @@ function formatAlternativesWithFactoring(
     return enumerateOrCommonFallback(reducedAlternatives, commonRendered, inputAtUnion, formatChildIssue);
 }
 
+function formatRelevantAlternatives(
+    alternatives: readonly AlternativeBucket[],
+    valueAtUnion: unknown,
+    formatChildIssue: FormatChildIssue
+): string | null {
+    return tryCollapseToOneOfMessage(alternatives, valueAtUnion)
+        ?? renderOnlyAlternative(alternatives, valueAtUnion, formatChildIssue)
+        ?? formatAlternativesWithFactoring(alternatives, valueAtUnion, formatChildIssue);
+}
+
 function buildUnionMessage(
     issue: $ZodIssueInvalidUnion,
     valueAtUnion: unknown,
@@ -372,18 +422,10 @@ function buildUnionMessage(
 ): string {
     const expanded = expandAlternatives(issue.errors);
     const relativeAlternatives = makeRelativeAlternatives(expanded, issue.path);
-
-    const collapsed = tryCollapseToOneOfMessage(relativeAlternatives, valueAtUnion);
-    if (collapsed !== null) {
-        return collapsed;
-    }
-
-    const factored = formatAlternativesWithFactoring(relativeAlternatives, valueAtUnion, formatChildIssue);
-    if (factored !== null) {
-        return factored;
-    }
-
-    return 'invalid value doesn’t match expected union';
+    const relevantAlternatives = selectRelevantAlternatives(relativeAlternatives, valueAtUnion);
+    return tryCollapseInvalidValuePath(relativeAlternatives, valueAtUnion)
+        ?? formatRelevantAlternatives(relevantAlternatives, valueAtUnion, formatChildIssue)
+        ?? 'invalid value doesn’t match expected union';
 }
 
 export function formatInvalidUnionIssueMessage(

--- a/source/zod-error-formatter/issue-specific/too-big.test.ts
+++ b/source/zod-error-formatter/issue-specific/too-big.test.ts
@@ -67,6 +67,18 @@ test('formats the boundary correctly for array type with maximum 1', function ()
     assert.strictEqual(message, 'array must contain at most 1 element');
 });
 
+test('formats a missing inclusive flag as inclusive', function () {
+    const message = formatTooBigIssueMessage({
+        code: 'too_big',
+        path: [],
+        message: '',
+        input: '',
+        origin: 'array',
+        maximum: 1
+    });
+    assert.strictEqual(message, 'array must contain at most 1 element');
+});
+
 test('formats the boundary correctly for array type with maximum more than 1', function () {
     const message = formatTooBigIssueMessage({
         code: 'too_big',

--- a/source/zod-error-formatter/issue-specific/too-small.test.ts
+++ b/source/zod-error-formatter/issue-specific/too-small.test.ts
@@ -217,7 +217,8 @@ test('formats the predicate correctly when inclusive false for number type', fun
         message: '',
         input: '',
         origin: 'number',
-        minimum: 1
+        minimum: 1,
+        inclusive: false
     });
     assert.strictEqual(message, 'number must be greater than 1');
 });

--- a/source/zod-error-formatter/list.ts
+++ b/source/zod-error-formatter/list.ts
@@ -1,4 +1,4 @@
-import type { $ZodInvalidTypeExpected, util } from 'zod/v4/core';
+import type { $ZodIssueInvalidType, util } from 'zod/v4/core';
 import { isNonEmptyArray, type NonEmptyArray } from '../tuple/non-empty-array.ts';
 
 function joinList(values: NonEmptyArray<string>, separator: string, lastItemSeparator: string): string {
@@ -14,7 +14,7 @@ function joinList(values: NonEmptyArray<string>, separator: string, lastItemSepa
     return `${joinedInitialList}${lastItemSeparator}${lastItem}`;
 }
 
-type ParsedType = { readonly type: $ZodInvalidTypeExpected; };
+type ParsedType = { readonly type: $ZodIssueInvalidType['expected']; };
 export type ListValue = ParsedType | util.Primitive;
 
 export function isParsedType(value: ListValue): value is ParsedType {

--- a/source/zod-graphql-query-builder/query-schema.ts
+++ b/source/zod-graphql-query-builder/query-schema.ts
@@ -39,11 +39,11 @@ import { type CustomScalarSchema, isCustomScalarSchema } from './custom-scalar.t
  * blow the TypeScript instantiation depth when used in a recursive union (see
  * enormora/schema-hub#285). Two upstream bugs are involved:
  *
- *   - colinhacks/zod#4611 — the wrappers $ZodLazy/$ZodNullable/$ZodReadonly/
+ *   - colinhacks/zod#4611: the wrappers $ZodLazy/$ZodNullable/$ZodReadonly/
  *     $ZodPipe bubble `optin`/`optout`/`values`/`pattern`/`propValues` from
  *     their inner generic. The maintainer is "not planning to pursue a fix."
  *
- *   - colinhacks/zod#6015 — $ZodObject/$ZodArray/$ZodUnion/$ZodTuple/
+ *   - colinhacks/zod#6015: $ZodObject/$ZodArray/$ZodUnion/$ZodTuple/
  *     $ZodDiscriminatedUnion derive their `_zod.output`/`_zod.input` from
  *     their inner generic, which cycles in recursive unions once
  *     materialization is forced.
@@ -52,7 +52,7 @@ import { type CustomScalarSchema, isCustomScalarSchema } from './custom-scalar.t
  * runtime, which is enough for structural assignability from the real
  * `$Zod*` class. When the matching upstream issue is fixed, search for
  * `Gh4611` / `Gh6015` and swap that group back to the original `$Zod*<...>`
- * types — the deletion is mechanical.
+ * types. The deletion is mechanical.
  */
 interface ZodLazyGh4611IssueWorkaround<T extends $ZodType = $ZodType> extends $ZodType {
     readonly _zod: $ZodTypeInternals & { readonly def: $ZodLazyDef<T>; };
@@ -81,11 +81,10 @@ interface ZodUnionGh6015IssueWorkaround<T extends readonly $ZodType[] = readonly
     readonly _zod: $ZodTypeInternals & { readonly def: $ZodUnionDef<T>; };
 }
 interface ZodDiscriminatedUnionGh6015IssueWorkaround<
-    Options extends readonly $ZodType[] = readonly $ZodType[],
-    Disc extends string = string
+    Options extends readonly $ZodType[] = readonly $ZodType[]
 > extends $ZodType {
     readonly _zod: $ZodTypeInternals & {
-        readonly def: $ZodDiscriminatedUnionDef<Options, Disc>;
+        readonly def: $ZodDiscriminatedUnionDef<Options>;
         readonly propValues: zodUtil.PropValues;
     };
 }


### PR DESCRIPTION
This narrows nested object unions by literal fields and strict-object keys before formatting alternatives, so matching branches report their own field issues instead of a noisy outer union error.

It also aligns Zod-facing types and boundary formatting with the current `zod` issue shapes used by the formatter tests.