### PR TITLE
Fix boundary mutations crashing on negative literal values

### DIFF
--- a/source/stryker-zod-mutator/ast.ts
+++ b/source/stryker-zod-mutator/ast.ts
@@ -118,7 +118,7 @@ export function numericArgumentMutations(
 
     return [ -1, 1 ].map(function (offset) {
         const clone = babel.cloneNode<babel.CallExpression>(call, true);
-        clone.arguments[argumentIndex] = babel.numericLiteral(argument.value + offset);
+        clone.arguments[argumentIndex] = babel.valueToNode(argument.value + offset);
         return clone;
     });
 }

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -137,6 +137,31 @@ test('removes and changes string checks', function () {
     assert.ok(collectMutations(source, 'ZodStringBoundaryChange').includes('z.string().min(3)'));
 });
 
+test('changes boundaries and literals to negative values without aborting', function () {
+    assert.ok(
+        collectMutations(
+            "import { z } from 'zod'; const schema = z.number().check(z.gt(0));",
+            'ZodNumberBoundaryChange'
+        )
+            .includes('z.number().check(z.gt(-1))')
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(0);", 'ZodStringBoundaryChange')
+            .includes('z.string().min(-1)')
+    );
+    assert.ok(
+        collectMutations(
+            "import { z } from 'zod/mini'; const schema = z.array(z.string()).check(z.minSize(0));",
+            'ZodCollectionBoundaryChange'
+        )
+            .includes('z.array(z.string()).check(z.minSize(-1))')
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.literal(0);", 'ZodNumericLiteralChange')
+            .includes('z.literal(-1)')
+    );
+});
+
 test('removes mini checks inside check calls', function () {
     const mutations = collectMutations(
         "import { z } from 'zod/mini'; const schema = z.string().check(z.minLength(2));",


### PR DESCRIPTION
`numericArgumentMutations` built each shifted argument with `babel.numericLiteral(value + offset)`. Since `@babel/types` v8 the `NumericLiteral` validator rejects negative numbers, so any boundary or literal mutation that shifted a value below zero threw and aborted instrumentation. This hit the reported `z.number().check(z.gt(0))` as well as cases like `z.string().min(0)`, `z.array(z.string()).check(z.minSize(0))`, and `z.literal(0)`.

Switching to `babel.valueToNode`, which emits a `UnaryExpression` for negatives, lets `ZodNumberBoundaryChange`, `ZodStringBoundaryChange`, `ZodCollectionBoundaryChange`, and `ZodNumericLiteralChange` produce valid mutants at zero boundaries instead of crashing.