### PR TITLE
Limit `ZodReadonlyAdd` to schemas where `readonly` has an effect

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -175,6 +175,60 @@ test('mutates readonly because it freezes parsed values at runtime', function ()
     );
 });
 
+test('adds readonly to collection schemas whose frozen output is observable', function () {
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.array(z.string());", 'ZodReadonlyAdd')
+            .includes('z.array(z.string()).readonly()')
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.tuple([z.string()]);", 'ZodReadonlyAdd')
+            .includes('z.tuple([z.string()]).readonly()')
+    );
+    assert.ok(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.record(z.string(), z.number());",
+            'ZodReadonlyAdd'
+        )
+            .includes('z.record(z.string(), z.number()).readonly()')
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.array(z.string()).min(1);", 'ZodReadonlyAdd')
+            .includes('z.array(z.string()).min(1).readonly()')
+    );
+});
+
+test('adds readonly through wrappers around a collection schema', function () {
+    assert.ok(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.object({ a: z.string() }).optional();",
+            'ZodReadonlyAdd'
+        )
+            .includes('z.object({\n  a: z.string()\n}).optional().readonly()')
+    );
+    assert.ok(
+        collectMutations(
+            "import * as z from 'zod/mini'; const schema = z.optional(z.object({ a: z.string() }));",
+            'ZodReadonlyAdd'
+        )
+            .includes('z.readonly(z.optional(z.object({\n  a: z.string()\n})))')
+    );
+});
+
+test('does not add readonly where freezing has no observable effect', function () {
+    const nonFreezableSources = [
+        "import { z } from 'zod/v4'; const schema = z.string();",
+        "import { z } from 'zod/v4'; const schema = z.number().check(z.gt(0));",
+        "import { z } from 'zod/v4'; const schema = z.enum(['a', 'b']);",
+        "import { z } from 'zod/v4'; const schema = z.literal('a');",
+        "import { z } from 'zod/v4'; const schema = z.string().optional();",
+        "import { string } from 'zod/mini'; const schema = string();"
+    ];
+
+    for (const source of nonFreezableSources) {
+        assert.deepStrictEqual(collectMutations(source, 'ZodReadonlyAdd'), []);
+    }
+});
+
 test('replaces coercion with strict schemas', function () {
     const mutations = collectMutations(
         "import { z } from 'zod/v4'; const schema = z.coerce.number();",
@@ -602,8 +656,8 @@ test('covers alias forms across phase one operators', function () {
         },
         {
             operator: 'ZodReadonlyAdd',
-            source: "import zod from 'zod/v4'; const schema = zod.string();",
-            expected: 'zod.string().readonly()'
+            source: "import zod from 'zod/v4'; const schema = zod.object({});",
+            expected: 'zod.object({}).readonly()'
         },
         {
             operator: 'ZodObjectFactorySwap',

--- a/source/stryker-zod-mutator/presence-mutations.ts
+++ b/source/stryker-zod-mutator/presence-mutations.ts
@@ -1,9 +1,20 @@
+import type { Node as BabelNode } from '@babel/types';
 import {
     addWrapperOrMethod,
     removeMethodOrWrapper,
     replaceNullish
 } from './schema-call-mutations.ts';
+import { isExpressionNode, type MutationPath } from './ast.ts';
 import { createDefinition, type MutationDefinition } from './mutation-definition.ts';
+import { producesFreezableValue, type ZodBindings } from './zod-bindings.ts';
+
+function addReadonlyToFreezableSchema(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
+    if (!isExpressionNode(path.node) || !producesFreezableValue(bindings, path.node)) {
+        return [];
+    }
+
+    return addWrapperOrMethod(path, bindings, 'readonly');
+}
 
 export const presenceMutationDefinitions: readonly MutationDefinition[] = [
     createDefinition('ZodOptionalAdd', function (path, bindings) {
@@ -30,9 +41,7 @@ export const presenceMutationDefinitions: readonly MutationDefinition[] = [
     createDefinition('ZodNonoptionalRemove', function (path, bindings) {
         return removeMethodOrWrapper(path, bindings, new Set([ 'nonoptional' ]));
     }),
-    createDefinition('ZodReadonlyAdd', function (path, bindings) {
-        return addWrapperOrMethod(path, bindings, 'readonly');
-    }),
+    createDefinition('ZodReadonlyAdd', addReadonlyToFreezableSchema),
     createDefinition('ZodReadonlyRemove', function (path, bindings) {
         return removeMethodOrWrapper(path, bindings, new Set([ 'readonly' ]));
     })

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -164,6 +164,11 @@ The default set enables every operator below.
 `z.boolean()`, `z.date()`, `z.symbol()`, `z.null()`, `z.undefined()`, `z.void()`, `z.never()`, `z.any()`,
 and `z.unknown()`.
 
+`ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
+object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,
+`nonoptional`, `default`, `prefault`, or `catch`. Primitives and other schemas are skipped because freezing
+them has no effect.
+
 Boolean and string literal values are left to Stryker’s built-in literal mutators.
 
 ## Limits

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -324,3 +324,57 @@ export function firstExpressionArgument(call: CallExpression): SchemaExpression 
 export function isObjectLikeFactory(name: string): boolean {
     return [ 'object', 'strictObject', 'looseObject' ].includes(name);
 }
+
+const freezableSchemaFactoryNames = new Set([
+    'object',
+    'strictObject',
+    'looseObject',
+    'array',
+    'tuple',
+    'record',
+    'partialRecord',
+    'looseRecord'
+]);
+
+const valuePreservingWrapperNames = new Set([
+    'optional',
+    'nullable',
+    'nullish',
+    'nonoptional',
+    '_default',
+    'prefault',
+    'catch',
+    'readonly'
+]);
+
+function isFreezableFactoryCall(bindings: ZodBindings, call: CallExpression): boolean {
+    const callName = getZodCallName(bindings, call);
+
+    return callName !== null && freezableSchemaFactoryNames.has(callName);
+}
+
+function underlyingSchemaExpression(bindings: ZodBindings, call: CallExpression): SchemaExpression | null {
+    const callName = getZodCallName(bindings, call);
+
+    if (callName !== null && valuePreservingWrapperNames.has(callName)) {
+        return firstExpressionArgument(call);
+    }
+
+    return babel.isMemberExpression(call.callee) && isExpressionNode(call.callee.object)
+        ? call.callee.object
+        : null;
+}
+
+export function producesFreezableValue(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    let current: SchemaExpression | null = expression;
+
+    while (current !== null && babel.isCallExpression(current)) {
+        if (isFreezableFactoryCall(bindings, current)) {
+            return true;
+        }
+
+        current = underlyingSchemaExpression(bindings, current);
+    }
+
+    return false;
+}


### PR DESCRIPTION
`.readonly()` freezes the parsed value via `Object.freeze`, so the mutation is only observable when the output is a mutable reference: the object, `array`, `tuple`, and record families. Previously `ZodReadonlyAdd` wrapped every schema, so primitives, enums, and literals produced equivalent mutants that no test could kill.

`ZodReadonlyAdd` is now gated on `producesFreezableValue`, which walks a schema expression to its underlying factory, unwrapping value-preserving wrappers (`optional`, `nullable`, `nullish`, `nonoptional`, `default`, `prefault`, `catch`, `readonly`) in both classic and mini styles, and only offers the mutation when that factory produces a freezable collection.