### PR TITLE
Stop `ZodReadonlyAdd` from re-wrapping already-readonly schemas

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -254,6 +254,37 @@ test('does not add readonly where freezing has no observable effect', function (
     }
 });
 
+test('does not add readonly to schemas that are already readonly', function () {
+    const alreadyReadonlySources = [
+        "import { z } from 'zod/v4'; const schema = z.object({ a: z.string() }).readonly();",
+        "import * as z from 'zod/mini'; const schema = z.readonly(z.object({ a: z.string() }));",
+        "import { z } from 'zod/v4'; const schema = z.array(z.string()).readonly();",
+        "import { z } from 'zod/v4'; const schema = z.object({ a: z.string() }).readonly().optional();",
+        "import { z } from 'zod/v4'; const schema = z.array(z.string()).min(1).readonly();"
+    ];
+
+    for (const source of alreadyReadonlySources) {
+        assert.deepStrictEqual(collectMutations(source, 'ZodReadonlyAdd'), []);
+    }
+});
+
+test('adds readonly once per schema value and leaves an already readonly field untouched', function () {
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.object({ a: z.string() }).optional();",
+            'ZodReadonlyAdd'
+        ),
+        [ 'z.object({\n  a: z.string()\n}).optional().readonly()' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.object({ a: z.array(z.string()).readonly() });",
+            'ZodReadonlyAdd'
+        ),
+        [ 'z.object({\n  a: z.array(z.string()).readonly()\n}).readonly()' ]
+    );
+});
+
 test('replaces coercion with strict schemas', function () {
     const mutations = collectMutations(
         "import { z } from 'zod/v4'; const schema = z.coerce.number();",

--- a/source/stryker-zod-mutator/presence-mutations.ts
+++ b/source/stryker-zod-mutator/presence-mutations.ts
@@ -6,10 +6,19 @@ import {
 } from './schema-call-mutations.ts';
 import { isExpressionNode, type MutationPath } from './ast.ts';
 import { createDefinition, type MutationDefinition } from './mutation-definition.ts';
-import { producesFreezableValue, type ZodBindings } from './zod-bindings.ts';
+import {
+    chainAppliesReadonly,
+    isSchemaValueChainRoot,
+    producesFreezableValue,
+    type ZodBindings
+} from './zod-bindings.ts';
 
 function addReadonlyToFreezableSchema(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
-    if (!isExpressionNode(path.node) || !producesFreezableValue(bindings, path.node)) {
+    if (!isExpressionNode(path.node) || !isSchemaValueChainRoot(path, bindings)) {
+        return [];
+    }
+
+    if (!producesFreezableValue(bindings, path.node) || chainAppliesReadonly(bindings, path.node)) {
         return [];
     }
 

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -167,7 +167,8 @@ and `z.unknown()`.
 `ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,
 `nonoptional`, `default`, `prefault`, or `catch`. Primitives and other schemas are skipped because freezing
-them has no effect.
+them has no effect. It emits a single mutant per schema value and skips schemas that already apply
+`readonly` anywhere in that chain, so it never produces a redundant double `readonly`.
 
 Boolean and string literal values are left to Stryker’s built-in literal mutators.
 

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -378,3 +378,49 @@ export function producesFreezableValue(bindings: ZodBindings, expression: Schema
 
     return false;
 }
+
+function isReadonlyApplication(bindings: ZodBindings, call: CallExpression): boolean {
+    return getZodCallName(bindings, call) === 'readonly' || getMemberName(call.callee) === 'readonly';
+}
+
+export function chainAppliesReadonly(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    let current: SchemaExpression | null = expression;
+
+    while (current !== null && babel.isCallExpression(current)) {
+        if (isReadonlyApplication(bindings, current)) {
+            return true;
+        }
+
+        current = underlyingSchemaExpression(bindings, current);
+    }
+
+    return false;
+}
+
+function isReceiverOfMethodCall(path: MutationPath): boolean {
+    const enclosingMember = path.parentPath?.node;
+
+    return babel.isMemberExpression(enclosingMember) && enclosingMember.object === path.node;
+}
+
+function isArgumentOfValuePreservingWrapper(path: MutationPath, bindings: ZodBindings): boolean {
+    const enclosingCall = path.parentPath?.node;
+
+    if (!babel.isCallExpression(enclosingCall)) {
+        return false;
+    }
+
+    const firstArgument = enclosingCall.arguments[0];
+
+    if (!isExpressionNode(firstArgument)) {
+        return false;
+    }
+
+    const wrapsThisNode = firstArgument === path.node;
+
+    return wrapsThisNode && valuePreservingWrapperNames.has(getZodCallName(bindings, enclosingCall) ?? '');
+}
+
+export function isSchemaValueChainRoot(path: MutationPath, bindings: ZodBindings): boolean {
+    return !isReceiverOfMethodCall(path) && !isArgumentOfValuePreservingWrapper(path, bindings);
+}


### PR DESCRIPTION
Adding `.readonly()` to a schema whose value is already frozen is an equivalent mutant: `Object.freeze` runs a second time with no additional observable effect. `ZodReadonlyAdd` emitted these from every node in a schema chain, so `z.object({}).readonly()`, `z.readonly(z.object({}))`, and `z.object({}).readonly().optional()` all produced a redundant double `readonly`.

The mutation is now offered only at the root of a schema value chain and only when no `readonly` already appears in that chain. Each freezable schema value therefore yields exactly one `readonly` mutant, and already-readonly schemas yield none. A non-readonly schema that contains an already-readonly field still gets its own `readonly` while the field is left untouched.