### PR TITLE
Prune runtime-equivalent `ZodPrimitiveFactorySwap` and `ZodObjectPolicyAdd` mutants

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -349,6 +349,53 @@ test('swaps direct mini primitive factories through available imports', function
     assert.deepStrictEqual(mutations, [ 'number()', 'nil()' ]);
 });
 
+test('does not swap primitives to a runtime-equivalent factory', function () {
+    const fromAny = collectMutations("import { z } from 'zod/v4'; const schema = z.any();", 'ZodPrimitiveFactorySwap');
+    const fromVoid = collectMutations(
+        "import { z } from 'zod/v4'; const schema = z.void();",
+        'ZodPrimitiveFactorySwap'
+    );
+
+    assert.ok(!fromAny.includes('z.unknown()'));
+    assert.ok(fromAny.includes('z.string()'));
+    assert.ok(
+        !collectMutations("import { z } from 'zod/v4'; const schema = z.unknown();", 'ZodPrimitiveFactorySwap')
+            .includes('z.any()')
+    );
+    assert.ok(!fromVoid.includes('z.undefined()'));
+    assert.ok(fromVoid.includes('z.any()'));
+    assert.ok(
+        !collectMutations("import { z } from 'zod/v4'; const schema = z.undefined();", 'ZodPrimitiveFactorySwap')
+            .includes('z.void()')
+    );
+});
+
+test('adds only behavior-changing object policies', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.object({});", 'ZodObjectPolicyAdd'),
+        [ 'z.object({}).strict()', 'z.object({}).passthrough()' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.strictObject({});", 'ZodObjectPolicyAdd'),
+        [ 'z.strictObject({}).passthrough()', 'z.strictObject({}).strip()' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.looseObject({});", 'ZodObjectPolicyAdd'),
+        [ 'z.looseObject({}).strict()', 'z.looseObject({}).strip()' ]
+    );
+});
+
+test('does not add object policies to non-object schemas', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.number();", 'ZodObjectPolicyAdd'),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(2);", 'ZodObjectPolicyAdd'),
+        []
+    );
+});
+
 test('covers phase one presence and object operators', function () {
     const cases: readonly OperatorCase[] = [
         {

--- a/source/stryker-zod-mutator/object-mutations.ts
+++ b/source/stryker-zod-mutator/object-mutations.ts
@@ -111,20 +111,41 @@ function wrapObjectField(
     return wrapper === null ? null : replaceObjectProperty(objectExpression, index, wrapper);
 }
 
+const objectPolicyNames = [ 'strict', 'passthrough', 'strip' ];
+
+const defaultPolicyByObjectFactory = new Map([
+    [ 'object', 'strip' ],
+    [ 'strictObject', 'strict' ],
+    [ 'looseObject', 'passthrough' ]
+]);
+
+function classicObjectFactoryName(bindings: ZodBindings, expression: SchemaExpression): string | null {
+    if (!babel.isCallExpression(expression) || expressionStyle(bindings, expression) !== 'classic') {
+        return null;
+    }
+
+    const callName = getZodCallName(bindings, expression);
+
+    return callName !== null && isObjectLikeFactory(callName) ? callName : null;
+}
+
 function addObjectPolicy(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
     const expression = isExpressionNode(path.node) ? path.node : null;
+    const factoryName = expression === null ? null : classicObjectFactoryName(bindings, expression);
 
-    if (
-        expression === null ||
-        expressionStyle(bindings, expression) !== 'classic' ||
-        !isZodSchemaExpression(bindings, expression)
-    ) {
+    if (expression === null || factoryName === null) {
         return [];
     }
 
-    return [ 'strict', 'passthrough', 'strip' ].map(function (name) {
-        return memberCall(cloneExpression(expression), name, []);
-    });
+    const defaultPolicy = defaultPolicyByObjectFactory.get(factoryName);
+
+    return objectPolicyNames
+        .filter(function (name) {
+            return name !== defaultPolicy;
+        })
+        .map(function (name) {
+            return memberCall(cloneExpression(expression), name, []);
+        });
 }
 
 export const objectMutationDefinitions: readonly MutationDefinition[] = [

--- a/source/stryker-zod-mutator/primitive-mutations.ts
+++ b/source/stryker-zod-mutator/primitive-mutations.ts
@@ -11,8 +11,19 @@ import type { MutationPath } from './ast.ts';
 
 const primitiveFactoryNameSet = new Set<string>(primitiveFactoryNames);
 
-function isPrimitiveFactoryCall(callName: string | null): boolean {
+const runtimeEquivalentFactories = new Map<string, ReadonlySet<string>>([
+    [ 'any', new Set([ 'unknown' ]) ],
+    [ 'unknown', new Set([ 'any' ]) ],
+    [ 'void', new Set([ 'undefined' ]) ],
+    [ 'undefined', new Set([ 'void' ]) ]
+]);
+
+function isPrimitiveFactoryCall(callName: string | null): callName is string {
     return callName !== null && primitiveFactoryNameSet.has(callName);
+}
+
+function isRuntimeEquivalentSwap(sourceName: string, targetName: string): boolean {
+    return runtimeEquivalentFactories.get(sourceName)?.has(targetName) ?? false;
 }
 
 function mutatePrimitiveFactory(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
@@ -30,7 +41,7 @@ function mutatePrimitiveFactory(path: MutationPath, bindings: ZodBindings): read
 
     return primitiveFactoryNames
         .filter(function (target) {
-            return target !== callName;
+            return target !== callName && !isRuntimeEquivalentSwap(callName, target);
         })
         .flatMap(function (target) {
             return replaceZodCallee(bindings, call, target) ?? [];

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -162,7 +162,13 @@ The default set enables every operator below.
 
 `ZodPrimitiveFactorySwap` swaps zero-argument calls among `z.string()`, `z.number()`, `z.bigint()`,
 `z.boolean()`, `z.date()`, `z.symbol()`, `z.null()`, `z.undefined()`, `z.void()`, `z.never()`, `z.any()`,
-and `z.unknown()`.
+and `z.unknown()`. It skips swaps between `z.any()` and `z.unknown()`, and between `z.void()` and
+`z.undefined()`, because those pairs validate identically at runtime and would only produce equivalent
+mutants.
+
+`ZodObjectPolicyAdd` applies only to the `object`, `strictObject`, and `looseObject` factories, and never
+adds the policy that already matches the factory default (`strip` for `object`, `strict` for
+`strictObject`, `passthrough` for `looseObject`), since that has no runtime effect.
 
 `ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,


### PR DESCRIPTION
Module-level schemas are static mutants (the mutated construction runs only at file load), so with `ignoreStatic` off Stryker reloads the environment and runs the full suite for each one. A surviving static mutant therefore costs a whole test run, and equivalent mutants always survive.

This removes two classes of runtime-equivalent (unkillable) mutants:

- `ZodPrimitiveFactorySwap` no longer swaps `z.any()` <-> `z.unknown()` or `z.void()` <-> `z.undefined()`. Each pair validates identically at runtime, so the swap has no observable effect.
- `ZodObjectPolicyAdd` now applies only to the `object`, `strictObject`, and `looseObject` factories, and never adds the policy that already matches the factory default (`strip`/`strict`/`passthrough`). This also drops the previously emitted invalid mutants on non-objects such as `z.number().strict()`, which threw at construction.