### PR TITLE
Skip no-effect `optional`/`nullable` adds on schemas that already accept the value

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -118,6 +118,51 @@ test('adds mini optional as a wrapper', function () {
     assert.ok(mutations.includes('schema.optional(schema.string())'));
 });
 
+test('does not add optional to schemas that already accept undefined', function () {
+    for (const factory of [ 'any', 'unknown', 'undefined', 'void' ]) {
+        assert.deepStrictEqual(
+            collectMutations(`import { z } from 'zod/v4'; const schema = z.${factory}();`, 'ZodOptionalAdd'),
+            []
+        );
+    }
+
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.null();", 'ZodOptionalAdd')
+            .includes('z.null().optional()')
+    );
+});
+
+test('does not add nullable to schemas that already accept null', function () {
+    for (const factory of [ 'any', 'unknown', 'null' ]) {
+        assert.deepStrictEqual(
+            collectMutations(`import { z } from 'zod/v4'; const schema = z.${factory}();`, 'ZodNullableAdd'),
+            []
+        );
+    }
+
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.undefined();", 'ZodNullableAdd')
+            .includes('z.undefined().nullable()')
+    );
+});
+
+test('does not add a no-effect presence wrapper to object fields', function () {
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.object({ a: z.any(), b: z.string() });",
+            'ZodObjectFieldOptionalAdd'
+        ),
+        [ 'z.object({\n  a: z.any(),\n  b: z.string().optional()\n})' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.object({ a: z.null(), b: z.string() });",
+            'ZodObjectFieldNullableAdd'
+        ),
+        [ 'z.object({\n  a: z.null(),\n  b: z.string().nullable()\n})' ]
+    );
+});
+
 test('removes object fields and wraps object fields', function () {
     const source = "import { z } from 'zod/v4'; const schema = z.object({ a: z.string(), b: z.number() });";
 

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -349,6 +349,53 @@ test('swaps direct mini primitive factories through available imports', function
     assert.deepStrictEqual(mutations, [ 'number()', 'nil()' ]);
 });
 
+test('does not swap primitives to a runtime-equivalent factory', function () {
+    const fromAny = collectMutations("import { z } from 'zod/v4'; const schema = z.any();", 'ZodPrimitiveFactorySwap');
+    const fromVoid = collectMutations(
+        "import { z } from 'zod/v4'; const schema = z.void();",
+        'ZodPrimitiveFactorySwap'
+    );
+
+    assert.ok(!fromAny.includes('z.unknown()'));
+    assert.ok(fromAny.includes('z.string()'));
+    assert.ok(
+        !collectMutations("import { z } from 'zod/v4'; const schema = z.unknown();", 'ZodPrimitiveFactorySwap')
+            .includes('z.any()')
+    );
+    assert.ok(!fromVoid.includes('z.undefined()'));
+    assert.ok(fromVoid.includes('z.any()'));
+    assert.ok(
+        !collectMutations("import { z } from 'zod/v4'; const schema = z.undefined();", 'ZodPrimitiveFactorySwap')
+            .includes('z.void()')
+    );
+});
+
+test('adds only behavior-changing object policies', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.object({});", 'ZodObjectPolicyAdd'),
+        [ 'z.object({}).strict()', 'z.object({}).passthrough()' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.strictObject({});", 'ZodObjectPolicyAdd'),
+        [ 'z.strictObject({}).passthrough()', 'z.strictObject({}).strip()' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.looseObject({});", 'ZodObjectPolicyAdd'),
+        [ 'z.looseObject({}).strict()', 'z.looseObject({}).strip()' ]
+    );
+});
+
+test('does not add object policies to non-object schemas', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.number();", 'ZodObjectPolicyAdd'),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(2);", 'ZodObjectPolicyAdd'),
+        []
+    );
+});
+
 test('covers phase one presence and object operators', function () {
     const cases: readonly OperatorCase[] = [
         {

--- a/source/stryker-zod-mutator/object-mutations.ts
+++ b/source/stryker-zod-mutator/object-mutations.ts
@@ -111,20 +111,41 @@ function wrapObjectField(
     return wrapper === null ? null : replaceObjectProperty(objectExpression, index, wrapper);
 }
 
+const objectPolicyNames = [ 'strict', 'passthrough', 'strip' ];
+
+const defaultPolicyByObjectFactory = new Map([
+    [ 'object', 'strip' ],
+    [ 'strictObject', 'strict' ],
+    [ 'looseObject', 'passthrough' ]
+]);
+
+function classicObjectFactoryName(bindings: ZodBindings, expression: SchemaExpression): string | null {
+    if (!babel.isCallExpression(expression) || expressionStyle(bindings, expression) !== 'classic') {
+        return null;
+    }
+
+    const callName = getZodCallName(bindings, expression);
+
+    return callName !== null && isObjectLikeFactory(callName) ? callName : null;
+}
+
 function addObjectPolicy(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
     const expression = isExpressionNode(path.node) ? path.node : null;
+    const factoryName = expression === null ? null : classicObjectFactoryName(bindings, expression);
 
-    if (
-        expression === null ||
-        expressionStyle(bindings, expression) !== 'classic' ||
-        !isZodSchemaExpression(bindings, expression)
-    ) {
+    if (expression === null || factoryName === null) {
         return [];
     }
 
-    return [ 'strict', 'passthrough', 'strip' ].map(function (name) {
-        return memberCall(cloneExpression(expression), name, []);
-    });
+    const defaultPolicy = defaultPolicyByObjectFactory.get(factoryName);
+
+    return objectPolicyNames
+        .filter(function (name) {
+            return name !== defaultPolicy;
+        })
+        .map(function (name) {
+            return memberCall(cloneExpression(expression), name, []);
+        });
 }
 
 export const objectMutationDefinitions: readonly MutationDefinition[] = [

--- a/source/stryker-zod-mutator/object-mutations.ts
+++ b/source/stryker-zod-mutator/object-mutations.ts
@@ -12,6 +12,7 @@ import {
 } from './ast.ts';
 import { callNode, createDefinition, type MutationDefinition } from './mutation-definition.ts';
 import {
+    addingWrapperHasNoEffect,
     buildZodCall,
     expressionStyle,
     getZodCallName,
@@ -93,12 +94,16 @@ function objectFieldValue(objectExpression: ObjectExpression, index: number): Sc
         : null;
 }
 
-function wrapObjectField(
+type FieldWrapTarget = {
+    readonly value: SchemaExpression;
+    readonly style: ZodApiStyle;
+};
+
+function fieldWrapTarget(
     bindings: ZodBindings,
     objectExpression: ObjectExpression,
-    index: number,
-    wrapperName: string
-): ObjectExpression | null {
+    index: number
+): FieldWrapTarget | null {
     const value = objectFieldValue(objectExpression, index);
     const style = value === null ? null : expressionStyle(bindings, value);
 
@@ -106,7 +111,22 @@ function wrapObjectField(
         return null;
     }
 
-    const wrapper = buildFieldWrapper(bindings, value, style, wrapperName);
+    return { value, style };
+}
+
+function wrapObjectField(
+    bindings: ZodBindings,
+    objectExpression: ObjectExpression,
+    index: number,
+    wrapperName: string
+): ObjectExpression | null {
+    const target = fieldWrapTarget(bindings, objectExpression, index);
+
+    if (target === null || addingWrapperHasNoEffect(bindings, target.value, wrapperName)) {
+        return null;
+    }
+
+    const wrapper = buildFieldWrapper(bindings, target.value, target.style, wrapperName);
 
     return wrapper === null ? null : replaceObjectProperty(objectExpression, index, wrapper);
 }

--- a/source/stryker-zod-mutator/primitive-mutations.ts
+++ b/source/stryker-zod-mutator/primitive-mutations.ts
@@ -11,8 +11,19 @@ import type { MutationPath } from './ast.ts';
 
 const primitiveFactoryNameSet = new Set<string>(primitiveFactoryNames);
 
-function isPrimitiveFactoryCall(callName: string | null): boolean {
+const runtimeEquivalentFactories = new Map<string, ReadonlySet<string>>([
+    [ 'any', new Set([ 'unknown' ]) ],
+    [ 'unknown', new Set([ 'any' ]) ],
+    [ 'void', new Set([ 'undefined' ]) ],
+    [ 'undefined', new Set([ 'void' ]) ]
+]);
+
+function isPrimitiveFactoryCall(callName: string | null): callName is string {
     return callName !== null && primitiveFactoryNameSet.has(callName);
+}
+
+function isRuntimeEquivalentSwap(sourceName: string, targetName: string): boolean {
+    return runtimeEquivalentFactories.get(sourceName)?.has(targetName) ?? false;
 }
 
 function mutatePrimitiveFactory(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
@@ -30,7 +41,7 @@ function mutatePrimitiveFactory(path: MutationPath, bindings: ZodBindings): read
 
     return primitiveFactoryNames
         .filter(function (target) {
-            return target !== callName;
+            return target !== callName && !isRuntimeEquivalentSwap(callName, target);
         })
         .flatMap(function (target) {
             return replaceZodCallee(bindings, call, target) ?? [];

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -162,7 +162,13 @@ The default set enables every operator below.
 
 `ZodPrimitiveFactorySwap` swaps zero-argument calls among `z.string()`, `z.number()`, `z.bigint()`,
 `z.boolean()`, `z.date()`, `z.symbol()`, `z.null()`, `z.undefined()`, `z.void()`, `z.never()`, `z.any()`,
-and `z.unknown()`.
+and `z.unknown()`. It skips swaps between `z.any()` and `z.unknown()`, and between `z.void()` and
+`z.undefined()`, because those pairs validate identically at runtime and would only produce equivalent
+mutants.
+
+`ZodObjectPolicyAdd` applies only to the `object`, `strictObject`, and `looseObject` factories, and never
+adds the policy that already matches the factory default (`strip` for `object`, `strict` for
+`strictObject`, `passthrough` for `looseObject`), since that has no runtime effect.
 
 `ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -170,6 +170,11 @@ mutants.
 adds the policy that already matches the factory default (`strip` for `object`, `strict` for
 `strictObject`, `passthrough` for `looseObject`), since that has no runtime effect.
 
+`ZodOptionalAdd` and `ZodObjectFieldOptionalAdd` skip schemas that already accept `undefined` (`z.any()`,
+`z.unknown()`, `z.undefined()`, `z.void()`), and `ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip
+schemas that already accept `null` (`z.any()`, `z.unknown()`, `z.null()`), because wrapping them changes
+nothing at runtime.
+
 `ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,
 `nonoptional`, `default`, `prefault`, or `catch`. Primitives and other schemas are skipped because freezing

--- a/source/stryker-zod-mutator/schema-call-mutations.ts
+++ b/source/stryker-zod-mutator/schema-call-mutations.ts
@@ -12,6 +12,7 @@ import {
 } from './ast.ts';
 import { callNode } from './mutation-definition.ts';
 import {
+    addingWrapperHasNoEffect,
     buildZodCall,
     expressionStyle,
     firstExpressionArgument,
@@ -90,6 +91,10 @@ function buildWrapperMutation(
     return wrapped === null ? [] : [ wrapped ];
 }
 
+function wrapperAlreadyApplied(expression: SchemaExpression, name: string): boolean {
+    return babel.isCallExpression(expression) && getCallName(expression.callee) === name;
+}
+
 export function addWrapperOrMethod(
     path: MutationPath,
     bindings: ZodBindings,
@@ -98,11 +103,11 @@ export function addWrapperOrMethod(
     const expression = zodSchemaExpression(path, bindings);
     const style = expression === null ? null : expressionStyle(bindings, expression);
 
-    if (
-        expression === null ||
-        style === null ||
-        babel.isCallExpression(expression) && getCallName(expression.callee) === name
-    ) {
+    if (expression === null || style === null) {
+        return [];
+    }
+
+    if (wrapperAlreadyApplied(expression, name) || addingWrapperHasNoEffect(bindings, expression, name)) {
         return [];
     }
 

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -424,3 +424,27 @@ function isArgumentOfValuePreservingWrapper(path: MutationPath, bindings: ZodBin
 export function isSchemaValueChainRoot(path: MutationPath, bindings: ZodBindings): boolean {
     return !isReceiverOfMethodCall(path) && !isArgumentOfValuePreservingWrapper(path, bindings);
 }
+
+const factoryNamesAcceptingUndefined = new Set([ 'any', 'unknown', 'undefined', 'void' ]);
+const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null' ]);
+
+const alreadyAcceptedValueByWrapper = new Map<string, ReadonlySet<string>>([
+    [ 'optional', factoryNamesAcceptingUndefined ],
+    [ 'nullable', factoryNamesAcceptingNull ]
+]);
+
+export function addingWrapperHasNoEffect(
+    bindings: ZodBindings,
+    expression: SchemaExpression,
+    wrapperName: string
+): boolean {
+    const acceptingFactories = alreadyAcceptedValueByWrapper.get(wrapperName);
+
+    if (acceptingFactories === undefined || !babel.isCallExpression(expression)) {
+        return false;
+    }
+
+    const factoryName = getZodCallName(bindings, expression);
+
+    return factoryName !== null && acceptingFactories.has(factoryName);
+}


### PR DESCRIPTION
Continuing the equivalent-mutant pruning that keeps static (module-level) schema mutants from forcing full test-suite runs.

Wrapping a schema that already accepts `undefined` in `.optional()`, or one that already accepts `null` in `.nullable()`, has no runtime effect (verified against Zod: the accepted set and parsed output are identical), so the mutant can never be killed and always survives.

- `ZodOptionalAdd` and `ZodObjectFieldOptionalAdd` now skip `z.any()`, `z.unknown()`, `z.undefined()`, `z.void()`.
- `ZodNullableAdd` and `ZodObjectFieldNullableAdd` now skip `z.any()`, `z.unknown()`, `z.null()`.

Scoped to leaf factories so there is no chain-position ambiguity. Wrapper-chain cases (e.g. `.nullish()` already accepting both, and firing at multiple positions in one chain) are a separate chain-root concern, not addressed here.