### PR TITLE
Emit `optional`/`nullable` adds only at the schema value chain root

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -163,6 +163,17 @@ test('does not add a no-effect presence wrapper to object fields', function () {
     );
 });
 
+test('adds a presence wrapper only at the schema value chain root', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(2);", 'ZodOptionalAdd'),
+        [ 'z.string().min(2).optional()' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.array(z.string()).min(1);", 'ZodNullableAdd'),
+        [ 'z.array(z.string()).min(1).nullable()', 'z.string().nullable()' ]
+    );
+});
+
 test('removes object fields and wraps object fields', function () {
     const source = "import { z } from 'zod/v4'; const schema = z.object({ a: z.string(), b: z.number() });";
 

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -173,7 +173,9 @@ adds the policy that already matches the factory default (`strip` for `object`, 
 `ZodOptionalAdd` and `ZodObjectFieldOptionalAdd` skip schemas that already accept `undefined` (`z.any()`,
 `z.unknown()`, `z.undefined()`, `z.void()`), and `ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip
 schemas that already accept `null` (`z.any()`, `z.unknown()`, `z.null()`), because wrapping them changes
-nothing at runtime.
+nothing at runtime. `ZodOptionalAdd` and `ZodNullableAdd` also wrap only at the root of a schema value
+chain, so `z.string().min(2)` yields `z.string().min(2).optional()` rather than the invalid
+`z.string().optional().min(2)`.
 
 `ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,

--- a/source/stryker-zod-mutator/schema-call-mutations.ts
+++ b/source/stryker-zod-mutator/schema-call-mutations.ts
@@ -17,6 +17,7 @@ import {
     expressionStyle,
     firstExpressionArgument,
     getZodCallName,
+    isSchemaValueChainRoot,
     isZodSchemaExpression,
     type ZodApiStyle,
     type ZodBindings
@@ -95,6 +96,17 @@ function wrapperAlreadyApplied(expression: SchemaExpression, name: string): bool
     return babel.isCallExpression(expression) && getCallName(expression.callee) === name;
 }
 
+function shouldSkipWrapping(
+    path: MutationPath,
+    bindings: ZodBindings,
+    expression: SchemaExpression,
+    name: string
+): boolean {
+    return !isSchemaValueChainRoot(path, bindings) ||
+        wrapperAlreadyApplied(expression, name) ||
+        addingWrapperHasNoEffect(bindings, expression, name);
+}
+
 export function addWrapperOrMethod(
     path: MutationPath,
     bindings: ZodBindings,
@@ -107,7 +119,7 @@ export function addWrapperOrMethod(
         return [];
     }
 
-    if (wrapperAlreadyApplied(expression, name) || addingWrapperHasNoEffect(bindings, expression, name)) {
+    if (shouldSkipWrapping(path, bindings, expression, name)) {
         return [];
     }
 


### PR DESCRIPTION
Continues the equivalent-mutant pruning. `ZodOptionalAdd` and `ZodNullableAdd` fired on every node of a schema chain, so `z.string().min(2)` also produced `z.string().optional()`. Placed back into the chain that becomes `z.string().optional().min(2)`, which throws at construction (`.min` is not a function on `ZodOptional`). Being module-level, that broken mutant is static and wastes a full test run.

The add now happens once, at the chain root (reusing `isSchemaValueChainRoot` from the readonly work). Nested schemas that are their own chain root (object fields, array elements) still get their own mutant, e.g. `z.array(z.string()).min(1)` yields `z.array(z.string()).min(1).nullable()` and `z.string().nullable()`.