### PR TITLE
Eliminate equivalent presence-wrapper, record-swap, and record-key mutants

### DIFF
--- a/source/stryker-zod-mutator/collection-mutations.ts
+++ b/source/stryker-zod-mutator/collection-mutations.ts
@@ -114,11 +114,21 @@ function removeTupleRest(path: MutationPath, bindings: ZodBindings): readonly Ba
     return [ clone ];
 }
 
+function hasInfiniteStringKey(bindings: ZodBindings, call: CallExpression): boolean {
+    const key = call.arguments[0];
+
+    return isExpressionNode(key) && babel.isCallExpression(key) && getZodCallName(bindings, key) === 'string';
+}
+
 function swapRecordFactory(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
     const call = callNode(path);
     const currentName = call === null ? null : getZodCallName(bindings, call);
 
     if (call === null || currentName === null || ![ 'record', 'partialRecord', 'looseRecord' ].includes(currentName)) {
+        return [];
+    }
+
+    if (hasInfiniteStringKey(bindings, call)) {
         return [];
     }
 

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -174,6 +174,77 @@ test('adds a presence wrapper only at the schema value chain root', function () 
     );
 });
 
+test('does not re-wrap an already-optional or already-nullable object field', function () {
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.object({ a: z.string().optional(), b: z.number() });",
+            'ZodObjectFieldOptionalAdd'
+        ),
+        [ 'z.object({\n  a: z.string().optional(),\n  b: z.number().optional()\n})' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.object({ a: z.string().nullable(), b: z.number() });",
+            'ZodObjectFieldNullableAdd'
+        ),
+        [ 'z.object({\n  a: z.string().nullable(),\n  b: z.number().nullable()\n})' ]
+    );
+});
+
+test('does not add a presence wrapper when nullish already admits the value', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().nullish();", 'ZodOptionalAdd'),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().nullish();", 'ZodNullableAdd'),
+        []
+    );
+});
+
+test('does not swap record factories for infinite string keys', function () {
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.record(z.string(), z.number());",
+            'ZodRecordFactorySwap'
+        ),
+        []
+    );
+    assert.ok(
+        collectMutations(
+            "import { z } from 'zod/v4'; const schema = z.record(z.enum(['a']), z.number());",
+            'ZodRecordFactorySwap'
+        )
+            .includes("z.partialRecord(z.enum(['a']), z.number())")
+    );
+});
+
+test('does not swap a string record key to an accepts-anything schema', function () {
+    const keyMutations = collectMutations(
+        "import { z } from 'zod/v4'; const schema = z.record(z.string(), z.literal(1));",
+        'ZodPrimitiveFactorySwap'
+    );
+
+    assert.ok(!keyMutations.includes('z.any()'));
+    assert.ok(!keyMutations.includes('z.unknown()'));
+    assert.ok(keyMutations.includes('z.number()'));
+});
+
+test('does not remove a presence wrapper when the inner schema already admits the value', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.unknown().optional();", 'ZodOptionalRemove'),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.unknown().nullable();", 'ZodNullableRemove'),
+        []
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().optional();", 'ZodOptionalRemove')
+            .includes('z.string()')
+    );
+});
+
 test('removes object fields and wraps object fields', function () {
     const source = "import { z } from 'zod/v4'; const schema = z.object({ a: z.string(), b: z.number() });";
 
@@ -573,8 +644,8 @@ test('covers phase one check, collection, union, fallback, and coercion operator
         },
         {
             operator: 'ZodRecordFactorySwap',
-            source: "import { z } from 'zod/v4'; const schema = z.record(z.string(), z.string());",
-            expected: 'z.partialRecord(z.string(), z.string())'
+            source: "import { z } from 'zod/v4'; const schema = z.record(z.enum(['a', 'b']), z.string());",
+            expected: "z.partialRecord(z.enum(['a', 'b']), z.string())"
         },
         {
             operator: 'ZodUnionOptionRemove',

--- a/source/stryker-zod-mutator/presence-mutations.ts
+++ b/source/stryker-zod-mutator/presence-mutations.ts
@@ -7,6 +7,7 @@ import {
 import { isExpressionNode, type MutationPath } from './ast.ts';
 import { createDefinition, type MutationDefinition } from './mutation-definition.ts';
 import {
+    addingWrapperHasNoEffect,
     chainAppliesReadonly,
     isSchemaValueChainRoot,
     producesFreezableValue,
@@ -25,18 +26,28 @@ function addReadonlyToFreezableSchema(path: MutationPath, bindings: ZodBindings)
     return addWrapperOrMethod(path, bindings, 'readonly');
 }
 
+function removeRedundantPresenceWrapper(
+    path: MutationPath,
+    bindings: ZodBindings,
+    wrapperName: string
+): readonly BabelNode[] {
+    return removeMethodOrWrapper(path, bindings, new Set([ wrapperName ])).filter(function (inner) {
+        return !(isExpressionNode(inner) && addingWrapperHasNoEffect(bindings, inner, wrapperName));
+    });
+}
+
 export const presenceMutationDefinitions: readonly MutationDefinition[] = [
     createDefinition('ZodOptionalAdd', function (path, bindings) {
         return addWrapperOrMethod(path, bindings, 'optional');
     }),
     createDefinition('ZodOptionalRemove', function (path, bindings) {
-        return removeMethodOrWrapper(path, bindings, new Set([ 'optional' ]));
+        return removeRedundantPresenceWrapper(path, bindings, 'optional');
     }),
     createDefinition('ZodNullableAdd', function (path, bindings) {
         return addWrapperOrMethod(path, bindings, 'nullable');
     }),
     createDefinition('ZodNullableRemove', function (path, bindings) {
-        return removeMethodOrWrapper(path, bindings, new Set([ 'nullable' ]));
+        return removeRedundantPresenceWrapper(path, bindings, 'nullable');
     }),
     createDefinition('ZodNullishRemove', function (path, bindings) {
         return removeMethodOrWrapper(path, bindings, new Set([ 'nullish' ]));

--- a/source/stryker-zod-mutator/primitive-mutations.ts
+++ b/source/stryker-zod-mutator/primitive-mutations.ts
@@ -3,6 +3,7 @@ import { callNode, createDefinition, type MutationDefinition } from './mutation-
 import {
     getZodCallName,
     isCoerceCall,
+    isRecordKeyPosition,
     primitiveFactoryNames,
     replaceZodCallee,
     type ZodBindings
@@ -26,6 +27,12 @@ function isRuntimeEquivalentSwap(sourceName: string, targetName: string): boolea
     return runtimeEquivalentFactories.get(sourceName)?.has(targetName) ?? false;
 }
 
+const acceptsAnyKeyFactoryNames = new Set([ 'any', 'unknown' ]);
+
+function isStringRecordKey(path: MutationPath, bindings: ZodBindings, callName: string): boolean {
+    return callName === 'string' && isRecordKeyPosition(path, bindings);
+}
+
 function mutatePrimitiveFactory(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
     const call = callNode(path);
     const callName = call === null ? null : getZodCallName(bindings, call);
@@ -39,9 +46,13 @@ function mutatePrimitiveFactory(path: MutationPath, bindings: ZodBindings): read
         return [];
     }
 
+    const skipAcceptsAnyKey = isStringRecordKey(path, bindings, callName);
+
     return primitiveFactoryNames
         .filter(function (target) {
-            return target !== callName && !isRuntimeEquivalentSwap(callName, target);
+            const wouldNotChangeStringKey = skipAcceptsAnyKey && acceptsAnyKeyFactoryNames.has(target);
+
+            return target !== callName && !isRuntimeEquivalentSwap(callName, target) && !wouldNotChangeStringKey;
         })
         .flatMap(function (target) {
             return replaceZodCallee(bindings, call, target) ?? [];

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -164,18 +164,25 @@ The default set enables every operator below.
 `z.boolean()`, `z.date()`, `z.symbol()`, `z.null()`, `z.undefined()`, `z.void()`, `z.never()`, `z.any()`,
 and `z.unknown()`. It skips swaps between `z.any()` and `z.unknown()`, and between `z.void()` and
 `z.undefined()`, because those pairs validate identically at runtime and would only produce equivalent
-mutants.
+mutants. A `z.string()` used as a record key is never swapped to `z.any()` or `z.unknown()`, because object
+keys are always strings, so those accept exactly the same keys.
 
 `ZodObjectPolicyAdd` applies only to the `object`, `strictObject`, and `looseObject` factories, and never
 adds the policy that already matches the factory default (`strip` for `object`, `strict` for
 `strictObject`, `passthrough` for `looseObject`), since that has no runtime effect.
 
+`ZodRecordFactorySwap` skips records whose key is `z.string()`, because `record`, `partialRecord`, and
+`looseRecord` behave identically for an unbounded string key domain (the swap only matters for finite keys
+such as an `enum`).
+
 `ZodOptionalAdd` and `ZodObjectFieldOptionalAdd` skip schemas that already accept `undefined` (`z.any()`,
-`z.unknown()`, `z.undefined()`, `z.void()`), and `ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip
-schemas that already accept `null` (`z.any()`, `z.unknown()`, `z.null()`), because wrapping them changes
-nothing at runtime. `ZodOptionalAdd` and `ZodNullableAdd` also wrap only at the root of a schema value
-chain, so `z.string().min(2)` yields `z.string().min(2).optional()` rather than the invalid
-`z.string().optional().min(2)`.
+`z.unknown()`, `z.undefined()`, `z.void()`, `z.nullish()`, and anything already `optional`), and
+`ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip schemas that already accept `null` (`z.any()`,
+`z.unknown()`, `z.null()`, `z.nullish()`, and anything already `nullable`), because wrapping them changes
+nothing at runtime. `ZodOptionalRemove` and `ZodNullableRemove` likewise skip removals whose remaining
+schema still admits the value (e.g. removing `.optional()` from `z.unknown().optional()`). `ZodOptionalAdd`
+and `ZodNullableAdd` also wrap only at the root of a schema value chain, so `z.string().min(2)` yields
+`z.string().min(2).optional()` rather than the invalid `z.string().optional().min(2)`.
 
 `ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -403,7 +403,11 @@ function isReceiverOfMethodCall(path: MutationPath): boolean {
     return babel.isMemberExpression(enclosingMember) && enclosingMember.object === path.node;
 }
 
-function isArgumentOfValuePreservingWrapper(path: MutationPath, bindings: ZodBindings): boolean {
+function isFirstArgumentOfCallNamed(
+    path: MutationPath,
+    bindings: ZodBindings,
+    callNames: ReadonlySet<string>
+): boolean {
     const enclosingCall = path.parentPath?.node;
 
     if (!babel.isCallExpression(enclosingCall)) {
@@ -416,17 +420,23 @@ function isArgumentOfValuePreservingWrapper(path: MutationPath, bindings: ZodBin
         return false;
     }
 
-    const wrapsThisNode = firstArgument === path.node;
+    const isFirstArgument = firstArgument === path.node;
 
-    return wrapsThisNode && valuePreservingWrapperNames.has(getZodCallName(bindings, enclosingCall) ?? '');
+    return isFirstArgument && callNames.has(getZodCallName(bindings, enclosingCall) ?? '');
 }
 
 export function isSchemaValueChainRoot(path: MutationPath, bindings: ZodBindings): boolean {
-    return !isReceiverOfMethodCall(path) && !isArgumentOfValuePreservingWrapper(path, bindings);
+    return !isReceiverOfMethodCall(path) && !isFirstArgumentOfCallNamed(path, bindings, valuePreservingWrapperNames);
 }
 
-const factoryNamesAcceptingUndefined = new Set([ 'any', 'unknown', 'undefined', 'void' ]);
-const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null' ]);
+const recordFactoryNames = new Set([ 'record', 'partialRecord', 'looseRecord' ]);
+
+export function isRecordKeyPosition(path: MutationPath, bindings: ZodBindings): boolean {
+    return isFirstArgumentOfCallNamed(path, bindings, recordFactoryNames);
+}
+
+const factoryNamesAcceptingUndefined = new Set([ 'any', 'unknown', 'undefined', 'void', 'nullish' ]);
+const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null', 'nullish' ]);
 
 const alreadyAcceptedValueByWrapper = new Map<string, ReadonlySet<string>>([
     [ 'optional', factoryNamesAcceptingUndefined ],
@@ -444,7 +454,7 @@ export function addingWrapperHasNoEffect(
         return false;
     }
 
-    const factoryName = getZodCallName(bindings, expression);
+    const outerName = getZodCallName(bindings, expression) ?? getMemberName(expression.callee) ?? '';
 
-    return factoryName !== null && acceptingFactories.has(factoryName);
+    return outerName === wrapperName || acceptingFactories.has(outerName);
 }


### PR DESCRIPTION
Closes the five equivalent-mutant categories from consumer feedback. Each produced a mutant identical to the original, so it always survived and, on a module-level (static) schema, forced a full test-suite run. All equivalences were verified against Zod at runtime.

- **1 & 2 (field variants):** `ZodObjectFieldOptionalAdd` / `ZodObjectFieldNullableAdd` no longer re-wrap a field that is already `optional`/`nullable`. `addingWrapperHasNoEffect` now also treats the wrapper's own name and `nullish` as already admitting the value, and detects classic-chained wrappers via the callee name. The non-field halves were already fixed by the chain-root change in #483.
- **5 (remove side):** `ZodOptionalRemove` / `ZodNullableRemove` skip removals whose remaining schema still admits the value, e.g. `z.unknown().optional()` collapsing to `z.unknown()`.
- **3 (record swap):** `ZodRecordFactorySwap` skips records keyed by `z.string()`, where `record`, `partialRecord`, and `looseRecord` are indistinguishable. The swap still applies for finite keys such as an `enum`.
- **4 (record key):** `ZodPrimitiveFactorySwap` no longer swaps a `z.string()` record key to `z.any()` or `z.unknown()`, which accept the same always-string keys. Swaps of a record *value* to `any`/`unknown` remain, since those are killable.

`isFirstArgumentOfCallNamed` unifies the value-preserving-wrapper-argument and record-key position checks.
