### PR TITLE
Eliminate no-op readonly removals and vacuous length lower bounds

### DIFF
--- a/source/stryker-zod-mutator/check-mutations.ts
+++ b/source/stryker-zod-mutator/check-mutations.ts
@@ -64,18 +64,87 @@ const strictnessSwaps = new Map([
     [ 'negative', 'nonpositive' ],
     [ 'nonpositive', 'negative' ]
 ]);
+const stringLengthLowerBoundNames = new Set([ 'min', 'minLength' ]);
+const collectionLengthLowerBoundNames = new Set([ 'min', 'minSize', 'minLength' ]);
+const noLengthLowerBoundNames: ReadonlySet<string> = new Set();
+
+type CheckNames = {
+    readonly methodNames: ReadonlySet<string>;
+    readonly miniNames: ReadonlySet<string>;
+    readonly lengthLowerBoundNames: ReadonlySet<string>;
+};
+
+const stringCheckConfig: CheckNames = {
+    methodNames: stringCheckNames,
+    miniNames: stringMiniCheckNames,
+    lengthLowerBoundNames: stringLengthLowerBoundNames
+};
+const numberCheckConfig: CheckNames = {
+    methodNames: numberCheckNames,
+    miniNames: numberMiniCheckNames,
+    lengthLowerBoundNames: noLengthLowerBoundNames
+};
+const collectionCheckConfig: CheckNames = {
+    methodNames: collectionCheckNames,
+    miniNames: collectionMiniCheckNames,
+    lengthLowerBoundNames: collectionLengthLowerBoundNames
+};
+
+function numericArgumentValue(call: CallExpression): number | null {
+    const argument = call.arguments[0];
+
+    if (babel.isNumericLiteral(argument)) {
+        return argument.value;
+    }
+
+    if (babel.isUnaryExpression(argument) && argument.operator === '-' && babel.isNumericLiteral(argument.argument)) {
+        return -argument.argument.value;
+    }
+
+    return null;
+}
+
+function isVacuousLengthBound(
+    name: string | null,
+    call: CallExpression,
+    lengthLowerBoundNames: ReadonlySet<string>
+): boolean {
+    const value = numericArgumentValue(call);
+
+    return name !== null && value !== null && value <= 0 && lengthLowerBoundNames.has(name);
+}
+
+function meaningfulBoundaryMutants(
+    mutants: readonly babel.CallExpression[],
+    name: string | null,
+    call: CallExpression,
+    lengthLowerBoundNames: ReadonlySet<string>
+): readonly babel.CallExpression[] {
+    if (!isVacuousLengthBound(name, call, lengthLowerBoundNames)) {
+        return mutants;
+    }
+
+    return mutants.filter(function (mutant) {
+        return (numericArgumentValue(mutant) ?? 1) > 0;
+    });
+}
 
 function removeChecksFromCheckCall(
     call: CallExpression,
     bindings: ZodBindings,
-    names: ReadonlySet<string>
+    names: ReadonlySet<string>,
+    lengthLowerBoundNames: ReadonlySet<string>
 ): readonly BabelNode[] {
     if (!babel.isMemberExpression(call.callee) || getMemberName(call.callee) !== 'check') {
         return [];
     }
 
     return call.arguments.flatMap(function (argument, index) {
-        if (!babel.isCallExpression(argument) || !names.has(getZodCallName(bindings, argument) ?? '')) {
+        if (
+            !babel.isCallExpression(argument) ||
+            !names.has(getZodCallName(bindings, argument) ?? '') ||
+            isVacuousLengthBound(getZodCallName(bindings, argument), argument, lengthLowerBoundNames)
+        ) {
             return [];
         }
 
@@ -90,7 +159,8 @@ function removeChecksFromCheckCall(
 function mutateCheckCallBoundaries(
     call: CallExpression,
     bindings: ZodBindings,
-    names: ReadonlySet<string>
+    names: ReadonlySet<string>,
+    lengthLowerBoundNames: ReadonlySet<string>
 ): readonly BabelNode[] {
     if (!babel.isMemberExpression(call.callee) || getMemberName(call.callee) !== 'check') {
         return [];
@@ -101,7 +171,14 @@ function mutateCheckCallBoundaries(
             return [];
         }
 
-        return numericArgumentMutations(argument, 0).map(function (mutatedCheck) {
+        const mutants = meaningfulBoundaryMutants(
+            numericArgumentMutations(argument, 0),
+            getZodCallName(bindings, argument),
+            argument,
+            lengthLowerBoundNames
+        );
+
+        return mutants.map(function (mutatedCheck) {
             const clone = babel.cloneNode<babel.CallExpression>(call, true);
             clone.arguments[index] = mutatedCheck;
             return clone;
@@ -109,41 +186,41 @@ function mutateCheckCallBoundaries(
     });
 }
 
-function removeSchemaMethodChecks(
-    path: MutationPath,
-    bindings: ZodBindings,
-    methodNames: ReadonlySet<string>,
-    miniNames: ReadonlySet<string>
-): readonly BabelNode[] {
+function removeSchemaMethodChecks(path: MutationPath, bindings: ZodBindings, config: CheckNames): readonly BabelNode[] {
     const call = callNode(path);
 
     if (call === null) {
         return [];
     }
 
+    const methodName = babel.isMemberExpression(call.callee) ? getMemberName(call.callee) : null;
+    const methodRemovals = isVacuousLengthBound(methodName, call, config.lengthLowerBoundNames)
+        ? []
+        : removeMethod(call, bindings, config.methodNames);
+
     return [
-        ...removeMethod(call, bindings, methodNames),
-        ...removeChecksFromCheckCall(call, bindings, miniNames)
+        ...methodRemovals,
+        ...removeChecksFromCheckCall(call, bindings, config.miniNames, config.lengthLowerBoundNames)
     ];
 }
 
-function mutateSchemaBoundaries(
-    path: MutationPath,
-    bindings: ZodBindings,
-    methodNames: ReadonlySet<string>,
-    miniNames: ReadonlySet<string>
-): readonly BabelNode[] {
+function mutateSchemaBoundaries(path: MutationPath, bindings: ZodBindings, config: CheckNames): readonly BabelNode[] {
     const call = callNode(path);
 
     if (call === null) {
         return [];
     }
 
-    if (babel.isMemberExpression(call.callee) && methodNames.has(getMemberName(call.callee) ?? '')) {
-        return numericArgumentMutations(call, 0);
+    if (babel.isMemberExpression(call.callee) && config.methodNames.has(getMemberName(call.callee) ?? '')) {
+        return meaningfulBoundaryMutants(
+            numericArgumentMutations(call, 0),
+            getMemberName(call.callee),
+            call,
+            config.lengthLowerBoundNames
+        );
     }
 
-    return mutateCheckCallBoundaries(call, bindings, miniNames);
+    return mutateCheckCallBoundaries(call, bindings, config.miniNames, config.lengthLowerBoundNames);
 }
 
 function memberCallName(call: CallExpression | null): string | null {
@@ -191,23 +268,23 @@ function replaceStringFormat(path: MutationPath, bindings: ZodBindings): readonl
 
 export const checkMutationDefinitions: readonly MutationDefinition[] = [
     createDefinition('ZodStringCheckRemove', function (path, bindings) {
-        return removeSchemaMethodChecks(path, bindings, stringCheckNames, stringMiniCheckNames);
+        return removeSchemaMethodChecks(path, bindings, stringCheckConfig);
     }),
     createDefinition('ZodStringBoundaryChange', function (path, bindings) {
-        return mutateSchemaBoundaries(path, bindings, stringCheckNames, stringMiniCheckNames);
+        return mutateSchemaBoundaries(path, bindings, stringCheckConfig);
     }),
     createDefinition('ZodStringFormatToString', replaceStringFormat),
     createDefinition('ZodNumberCheckRemove', function (path, bindings) {
-        return removeSchemaMethodChecks(path, bindings, numberCheckNames, numberMiniCheckNames);
+        return removeSchemaMethodChecks(path, bindings, numberCheckConfig);
     }),
     createDefinition('ZodNumberBoundaryChange', function (path, bindings) {
-        return mutateSchemaBoundaries(path, bindings, numberCheckNames, numberMiniCheckNames);
+        return mutateSchemaBoundaries(path, bindings, numberCheckConfig);
     }),
     createDefinition('ZodNumberStrictnessSwap', swapStrictness),
     createDefinition('ZodCollectionCheckRemove', function (path, bindings) {
-        return removeSchemaMethodChecks(path, bindings, collectionCheckNames, collectionMiniCheckNames);
+        return removeSchemaMethodChecks(path, bindings, collectionCheckConfig);
     }),
     createDefinition('ZodCollectionBoundaryChange', function (path, bindings) {
-        return mutateSchemaBoundaries(path, bindings, collectionCheckNames, collectionMiniCheckNames);
+        return mutateSchemaBoundaries(path, bindings, collectionCheckConfig);
     })
 ];

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -273,15 +273,8 @@ test('changes boundaries and literals to negative values without aborting', func
             .includes('z.number().check(z.gt(-1))')
     );
     assert.ok(
-        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(0);", 'ZodStringBoundaryChange')
-            .includes('z.string().min(-1)')
-    );
-    assert.ok(
-        collectMutations(
-            "import { z } from 'zod/mini'; const schema = z.array(z.string()).check(z.minSize(0));",
-            'ZodCollectionBoundaryChange'
-        )
-            .includes('z.array(z.string()).check(z.minSize(-1))')
+        collectMutations("import { z } from 'zod/v4'; const schema = z.number().min(0);", 'ZodNumberBoundaryChange')
+            .includes('z.number().min(-1)')
     );
     assert.ok(
         collectMutations("import { z } from 'zod/v4'; const schema = z.literal(0);", 'ZodNumericLiteralChange')
@@ -296,6 +289,43 @@ test('removes mini checks inside check calls', function () {
     );
 
     assert.ok(mutations.includes('z.string().check()'));
+});
+
+test('does not remove readonly when the frozen value is a primitive', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().readonly();", 'ZodReadonlyRemove'),
+        []
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.object({}).readonly();", 'ZodReadonlyRemove')
+            .includes('z.object({})')
+    );
+});
+
+test('does not mutate a vacuous length lower bound', function () {
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(0);", 'ZodStringCheckRemove'),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(0);", 'ZodStringBoundaryChange'),
+        [ 'z.string().min(1)' ]
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/mini'; const schema = z.array(z.string()).check(z.minSize(0));",
+            'ZodCollectionBoundaryChange'
+        ),
+        [ 'z.array(z.string()).check(z.minSize(1))' ]
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.string().min(2);", 'ZodStringCheckRemove')
+            .includes('z.string()')
+    );
+    assert.ok(
+        collectMutations("import { z } from 'zod/v4'; const schema = z.number().min(0);", 'ZodNumberCheckRemove')
+            .includes('z.number()')
+    );
 });
 
 test('mutates tuple rest schemas', function () {
@@ -838,6 +868,22 @@ test('ignores non-schema and incomplete Zod-looking nodes', function () {
         {
             operator: 'ZodCustomBehaviorRemove',
             source: "import { z } from 'zod/mini'; const schema = z.string().check(other.custom(() => true));"
+        },
+        {
+            operator: 'ZodStringCheckRemove',
+            source: "import { z } from 'zod/mini'; const schema = z.string().check(customCheck);"
+        },
+        {
+            operator: 'ZodStringBoundaryChange',
+            source: "import { z } from 'zod/mini'; const schema = z.string().check(customCheck);"
+        },
+        {
+            operator: 'ZodStringCheckRemove',
+            source: "import { string } from 'zod/mini'; const schema = string();"
+        },
+        {
+            operator: 'ZodStringBoundaryChange',
+            source: "import { string } from 'zod/mini'; const schema = string();"
         }
     ];
 

--- a/source/stryker-zod-mutator/presence-mutations.ts
+++ b/source/stryker-zod-mutator/presence-mutations.ts
@@ -36,6 +36,12 @@ function removeRedundantPresenceWrapper(
     });
 }
 
+function removeObservableReadonly(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
+    return removeMethodOrWrapper(path, bindings, new Set([ 'readonly' ])).filter(function (inner) {
+        return isExpressionNode(inner) && producesFreezableValue(bindings, inner);
+    });
+}
+
 export const presenceMutationDefinitions: readonly MutationDefinition[] = [
     createDefinition('ZodOptionalAdd', function (path, bindings) {
         return addWrapperOrMethod(path, bindings, 'optional');
@@ -62,7 +68,5 @@ export const presenceMutationDefinitions: readonly MutationDefinition[] = [
         return removeMethodOrWrapper(path, bindings, new Set([ 'nonoptional' ]));
     }),
     createDefinition('ZodReadonlyAdd', addReadonlyToFreezableSchema),
-    createDefinition('ZodReadonlyRemove', function (path, bindings) {
-        return removeMethodOrWrapper(path, bindings, new Set([ 'readonly' ]));
-    })
+    createDefinition('ZodReadonlyRemove', removeObservableReadonly)
 ];

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -175,6 +175,12 @@ adds the policy that already matches the factory default (`strip` for `object`, 
 `looseRecord` behave identically for an unbounded string key domain (the swap only matters for finite keys
 such as an `enum`).
 
+`ZodStringCheckRemove`, `ZodCollectionCheckRemove`, `ZodStringBoundaryChange`, and
+`ZodCollectionBoundaryChange` treat a length lower bound of zero or less (`min(0)`, `minLength(0)`,
+`minSize(0)`) as vacuous: removing it changes nothing, and lowering it further keeps it vacuous, so neither
+mutation is emitted. Raising it (e.g. `min(0)` to `min(1)`) is still emitted, and numeric bounds such as
+`z.number().min(0)` are untouched because there negative values are meaningful.
+
 `ZodOptionalAdd` and `ZodObjectFieldOptionalAdd` skip schemas that already accept `undefined` (`z.any()`,
 `z.unknown()`, `z.undefined()`, `z.void()`, `z.nullish()`, and anything already `optional`), and
 `ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip schemas that already accept `null` (`z.any()`,
@@ -188,7 +194,9 @@ and `ZodNullableAdd` also wrap only at the root of a schema value chain, so `z.s
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,
 `nonoptional`, `default`, `prefault`, or `catch`. Primitives and other schemas are skipped because freezing
 them has no effect. It emits a single mutant per schema value and skips schemas that already apply
-`readonly` anywhere in that chain, so it never produces a redundant double `readonly`.
+`readonly` anywhere in that chain, so it never produces a redundant double `readonly`. `ZodReadonlyRemove`
+mirrors this: it removes `readonly` only when the underlying value is one of those freezable families, since
+removing it from a frozen primitive has no observable effect.
 
 Boolean and string literal values are left to Stryker’s built-in literal mutators.
 


### PR DESCRIPTION
Removes the last two equivalent-mutant cases (both produce a mutant identical to the original, so they always survive and, on a module-level static schema, force a full test-suite run). Verified against Zod at runtime.

- `ZodReadonlyRemove` now removes `.readonly()` only when the underlying value is a freezable collection (object/array/tuple/record families). Removing it from a frozen primitive such as `z.string().readonly()` has no observable effect. This mirrors `ZodReadonlyAdd`.
- `ZodStringCheckRemove`, `ZodCollectionCheckRemove`, `ZodStringBoundaryChange`, and `ZodCollectionBoundaryChange` treat a length lower bound of zero or less (`min(0)`, `minLength(0)`, `minSize(0)`) as vacuous: it is never removed, and its boundary is never lowered further. Raising it (`min(0)` to `min(1)`) is still emitted, and numeric bounds like `z.number().min(0)` are untouched, since there negative values are meaningful.

The length lower-bound names are threaded through the check operators via a `CheckNames` config object (empty for the number operators).
