### PR TITLE
Skip no-op `optional`/`nullable` on a `z.string()` template literal part

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -174,6 +174,40 @@ test('adds a presence wrapper only at the schema value chain root', function () 
     );
 });
 
+test('does not add a presence wrapper to a string template literal part', function () {
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const schema = z.templateLiteral(['f_', z.string()]);",
+            'ZodOptionalAdd'
+        ),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const schema = z.templateLiteral(['f_', z.string()]);",
+            'ZodNullableAdd'
+        ),
+        []
+    );
+});
+
+test('still wraps a non-string template literal part where it changes behavior', function () {
+    assert.ok(
+        collectMutations(
+            "import * as z from 'zod/mini'; const schema = z.templateLiteral(['p', z.number()]);",
+            'ZodOptionalAdd'
+        )
+            .includes('z.optional(z.number())')
+    );
+    assert.ok(
+        collectMutations(
+            "import * as z from 'zod/mini'; const schema = z.templateLiteral(['p', z.number()]);",
+            'ZodNullableAdd'
+        )
+            .includes('z.nullable(z.number())')
+    );
+});
+
 test('does not re-wrap an already-optional or already-nullable object field', function () {
     assert.deepStrictEqual(
         collectMutations(

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -188,7 +188,10 @@ mutation is emitted. Raising it (e.g. `min(0)` to `min(1)`) is still emitted, an
 nothing at runtime. `ZodOptionalRemove` and `ZodNullableRemove` likewise skip removals whose remaining
 schema still admits the value (e.g. removing `.optional()` from `z.unknown().optional()`). `ZodOptionalAdd`
 and `ZodNullableAdd` also wrap only at the root of a schema value chain, so `z.string().min(2)` yields
-`z.string().min(2).optional()` rather than the invalid `z.string().optional().min(2)`.
+`z.string().min(2).optional()` rather than the invalid `z.string().optional().min(2)`. They also skip a
+`z.string()` part of a `z.templateLiteral([...])`, because a template part compiles to a regex fragment
+and `z.string()` already matches both the empty string and `"null"`, so wrapping it changes nothing. Other
+part types (e.g. `z.number()`) are still wrapped, since there the wrappers are observable.
 
 `ZodReadonlyAdd` only targets schemas whose parsed value is frozen observably at runtime, namely the
 object, `array`, `tuple`, and record families, including those wrapped in `optional`, `nullable`, `nullish`,

--- a/source/stryker-zod-mutator/schema-call-mutations.ts
+++ b/source/stryker-zod-mutator/schema-call-mutations.ts
@@ -18,6 +18,7 @@ import {
     firstExpressionArgument,
     getZodCallName,
     isSchemaValueChainRoot,
+    isStringTemplateLiteralPart,
     isZodSchemaExpression,
     type ZodApiStyle,
     type ZodBindings
@@ -104,7 +105,8 @@ function shouldSkipWrapping(
 ): boolean {
     return !isSchemaValueChainRoot(path, bindings) ||
         wrapperAlreadyApplied(expression, name) ||
-        addingWrapperHasNoEffect(bindings, expression, name);
+        addingWrapperHasNoEffect(bindings, expression, name) ||
+        isStringTemplateLiteralPart(path, bindings);
 }
 
 export function addWrapperOrMethod(

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -435,6 +435,30 @@ export function isRecordKeyPosition(path: MutationPath, bindings: ZodBindings): 
     return isFirstArgumentOfCallNamed(path, bindings, recordFactoryNames);
 }
 
+function grandparentNode(path: MutationPath): BabelNode | null {
+    return path.parentPath?.parentPath?.node ?? null;
+}
+
+function isElementOfTemplateLiteralParts(path: MutationPath, bindings: ZodBindings): boolean {
+    const partsArray = path.parentPath?.node;
+    const templateCall = grandparentNode(path);
+
+    if (!babel.isArrayExpression(partsArray) || !babel.isCallExpression(templateCall)) {
+        return false;
+    }
+
+    const firstArgument = templateCall.arguments[0];
+    const arrayIsFirstArgument = isExpressionNode(firstArgument) && firstArgument === partsArray;
+
+    return arrayIsFirstArgument && getZodCallName(bindings, templateCall) === 'templateLiteral';
+}
+
+export function isStringTemplateLiteralPart(path: MutationPath, bindings: ZodBindings): boolean {
+    return babel.isCallExpression(path.node) &&
+        getZodCallName(bindings, path.node) === 'string' &&
+        isElementOfTemplateLiteralParts(path, bindings);
+}
+
 const factoryNamesAcceptingUndefined = new Set([ 'any', 'unknown', 'undefined', 'void', 'nullish' ]);
 const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null', 'nullish' ]);
 


### PR DESCRIPTION
Closes Category 6 from the consumer's equivalent-mutant report (the only remaining category).

A `z.templateLiteral([...])` compiles each part to a regex fragment. `z.string()` already matches both the empty string and `"null"`, so wrapping such a part in `optional` or `nullable` produces an identical regex, i.e. an equivalent mutant that always survives.

`ZodOptionalAdd` and `ZodNullableAdd` now skip a `z.string()` element of a `templateLiteral` parts array.

**Scope refinement vs the report:** the report suggested skipping for *any* template part, but that would suppress killable mutants. Verified against Zod (`zod/mini`): a `z.number()` or `enum` part does not match the empty string, so `optional`/`nullable` there change the accepted set and are killable. Example that distinguishes original from mutant:

```
z.templateLiteral(['p', z.number()])            // rejects 'p'
z.templateLiteral(['p', z.optional(z.number())]) // accepts 'p'
```

So the skip is scoped to `z.string()` parts only; other part types keep their mutants.
