### PR TITLE
Skip no-op presence wrappers over default schemas and wrapped `unknown`

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -208,6 +208,52 @@ test('still wraps a non-string template literal part where it changes behavior',
     );
 });
 
+test('does not add optional over a default-bearing schema', function () {
+    for (const factory of [ 'prefault', '_default' ]) {
+        assert.deepStrictEqual(
+            collectMutations(
+                `import * as z from 'zod/mini'; const schema = z.${factory}(z.boolean(), false);`,
+                'ZodOptionalAdd'
+            ),
+            []
+        );
+    }
+
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const schema = z.object({ a: z.prefault(z.boolean(), false) });",
+            'ZodObjectFieldOptionalAdd'
+        ),
+        []
+    );
+    assert.ok(
+        collectMutations("import * as z from 'zod/mini'; const schema = z.catch(z.boolean(), false);", 'ZodOptionalAdd')
+            .includes('z.optional(z.catch(z.boolean(), false))')
+    );
+});
+
+test('does not add a presence wrapper over a wrapped accept-anything schema', function () {
+    assert.deepStrictEqual(
+        collectMutations("import * as z from 'zod/mini'; const schema = z.optional(z.unknown());", 'ZodNullableAdd'),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const schema = z.object({ a: z.optional(z.unknown()) });",
+            'ZodObjectFieldNullableAdd'
+        ),
+        []
+    );
+    assert.ok(
+        collectMutations("import * as z from 'zod/mini'; const schema = z.optional(z.string());", 'ZodNullableAdd')
+            .includes('z.nullable(z.optional(z.string()))')
+    );
+    assert.ok(
+        collectMutations("import * as z from 'zod/mini'; const schema = z.optional(inner);", 'ZodNullableAdd')
+            .includes('z.nullable(z.optional(inner))')
+    );
+});
+
 test('does not re-wrap an already-optional or already-nullable object field', function () {
     assert.deepStrictEqual(
         collectMutations(

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -182,10 +182,12 @@ mutation is emitted. Raising it (e.g. `min(0)` to `min(1)`) is still emitted, an
 `z.number().min(0)` are untouched because there negative values are meaningful.
 
 `ZodOptionalAdd` and `ZodObjectFieldOptionalAdd` skip schemas that already accept `undefined` (`z.any()`,
-`z.unknown()`, `z.undefined()`, `z.void()`, `z.nullish()`, and anything already `optional`), and
-`ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip schemas that already accept `null` (`z.any()`,
-`z.unknown()`, `z.null()`, `z.nullish()`, and anything already `nullable`), because wrapping them changes
-nothing at runtime. `ZodOptionalRemove` and `ZodNullableRemove` likewise skip removals whose remaining
+`z.unknown()`, `z.undefined()`, `z.void()`, `z.nullish()`, a `default`/`prefault` schema, and anything
+already `optional`), and `ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip schemas that already accept
+`null` (`z.any()`, `z.unknown()`, `z.null()`, `z.nullish()`, and anything already `nullable`), because
+wrapping them changes nothing at runtime. Both also see through `optional`/`nullable` (and other
+value-preserving wrappers) to an `z.any()`/`z.unknown()` leaf, so e.g. `z.nullable(z.optional(z.unknown()))`
+is not emitted. `ZodOptionalRemove` and `ZodNullableRemove` likewise skip removals whose remaining
 schema still admits the value (e.g. removing `.optional()` from `z.unknown().optional()`). `ZodOptionalAdd`
 and `ZodNullableAdd` also wrap only at the root of a schema value chain, so `z.string().min(2)` yields
 `z.string().min(2).optional()` rather than the invalid `z.string().optional().min(2)`. They also skip a
@@ -208,3 +210,9 @@ Boolean and string literal values are left to Stryker’s built-in literal mutat
 This package monkeypatches Stryker internals because StrykerJS does not currently expose a custom mutator
 plugin API. It intentionally avoids cross-statement data-flow analysis and only mutates schema expressions
 that are visibly rooted in a detected Zod import.
+
+Because the equivalent-mutant checks are local to a single expression, a mutant can still be equivalent
+through a use-site elsewhere. For example a schema defined as `const s = z.union([...])` and consumed only
+as `z.nullable(s)` makes an added `nullable` inside `s` unobservable, but the added wrapper and the masking
+one live in different statements, so it is not detected here. Suppress such cases with a Stryker disable
+comment on the definition, or inline the schema at its use-site.

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -459,13 +459,47 @@ export function isStringTemplateLiteralPart(path: MutationPath, bindings: ZodBin
         isElementOfTemplateLiteralParts(path, bindings);
 }
 
-const factoryNamesAcceptingUndefined = new Set([ 'any', 'unknown', 'undefined', 'void', 'nullish' ]);
+const factoryNamesAcceptingUndefined = new Set([
+    'any',
+    'unknown',
+    'undefined',
+    'void',
+    'nullish',
+    'prefault',
+    'default',
+    '_default'
+]);
 const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null', 'nullish' ]);
+const acceptAnythingFactoryNames = new Set([ 'any', 'unknown' ]);
 
 const alreadyAcceptedValueByWrapper = new Map<string, ReadonlySet<string>>([
     [ 'optional', factoryNamesAcceptingUndefined ],
     [ 'nullable', factoryNamesAcceptingNull ]
 ]);
+
+function outerSchemaName(bindings: ZodBindings, call: CallExpression): string {
+    return getZodCallName(bindings, call) ?? getMemberName(call.callee) ?? '';
+}
+
+function resolvesToAcceptAnything(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    let current: SchemaExpression | null = expression;
+
+    while (current !== null && babel.isCallExpression(current)) {
+        const name = outerSchemaName(bindings, current);
+
+        if (acceptAnythingFactoryNames.has(name)) {
+            return true;
+        }
+
+        if (!valuePreservingWrapperNames.has(name)) {
+            return false;
+        }
+
+        current = underlyingSchemaExpression(bindings, current);
+    }
+
+    return false;
+}
 
 export function addingWrapperHasNoEffect(
     bindings: ZodBindings,
@@ -478,7 +512,9 @@ export function addingWrapperHasNoEffect(
         return false;
     }
 
-    const outerName = getZodCallName(bindings, expression) ?? getMemberName(expression.callee) ?? '';
+    const outerName = outerSchemaName(bindings, expression);
 
-    return outerName === wrapperName || acceptingFactories.has(outerName);
+    return outerName === wrapperName ||
+        acceptingFactories.has(outerName) ||
+        resolvesToAcceptAnything(bindings, expression);
 }


### PR DESCRIPTION
Addresses Categories 1 and 2 of the 0.0.7 reconverge report. Both are equivalent-mutant shapes in the "redundant wrapper" family; each verified against Zod at runtime.

**Category 1 — `optional` over a default-bearing schema.** `z.optional(z.prefault(x, d))` and `z.optional(z._default(x, d))` are equivalent to the unwrapped schema: `prefault`/`default` already substitute `d` for `undefined`, so `optional` adds nothing. `ZodOptionalAdd` and `ZodObjectFieldOptionalAdd` now skip a schema whose outer factory is `default`/`prefault` (both mini `_default` and classic `default` names).

Scope note: `catch` is deliberately **not** included. `z.optional(z.catch(x, d))` is *not* equivalent — `catch` turns `undefined` into its fallback, while `optional` short-circuits `undefined` to `undefined`, so that swap remains killable.

**Category 2 — presence wrapper over a wrapped `unknown`.** `z.nullable(z.optional(z.unknown()))` is equivalent to `z.optional(z.unknown())`. `ZodOptionalAdd`/`ZodNullableAdd` (and field variants) now see through `optional`/`nullable` and other value-preserving wrappers to an `any`/`unknown` leaf and skip the wrap.

**Category 3 — not implemented (by design).** The third category is a wrapper masked by a `nullable` at a *different* use-site (`const s = z.union([...])` consumed only as `z.nullable(s)`). Detecting it requires cross-statement data-flow, which this package intentionally avoids. It is now documented in the readme as a known limitation, with suggested suppression (a Stryker disable comment on the definition, or inlining the schema).
