### PR TITLE
Skip presence-wrapper mutants masked by every use of a module const

### DIFF
--- a/source/stryker-zod-mutator/masked-schema-references.ts
+++ b/source/stryker-zod-mutator/masked-schema-references.ts
@@ -1,0 +1,178 @@
+import * as babel from '@babel/types';
+import type { Node as BabelNode } from '@babel/types';
+import { findProgram, getMemberName, isExpressionNode, type MutationPath } from './ast.ts';
+import { getZodCallName, type ZodBindings } from './zod-bindings.ts';
+
+const unionFactoryNames = new Set([ 'union', 'discriminatedUnion' ]);
+
+const maskingWrappersByAddedWrapper = new Map<string, ReadonlySet<string>>([
+    [ 'nullable', new Set([ 'nullable', 'nullish' ]) ],
+    [ 'optional', new Set([ 'optional', 'nullish' ]) ]
+]);
+
+function isNonExportedModuleConst(declarationPath: MutationPath | null): boolean {
+    const declaration = declarationPath?.node;
+    const container = declarationPath?.parentPath?.node;
+
+    return babel.isVariableDeclaration(declaration) &&
+        declaration.kind === 'const' &&
+        babel.isProgram(container);
+}
+
+function declaratorInitId(declaratorPath: MutationPath | null, node: BabelNode): babel.Identifier | null {
+    if (declaratorPath === null || !babel.isVariableDeclarator(declaratorPath.node)) {
+        return null;
+    }
+
+    const { init, id } = declaratorPath.node;
+
+    return isExpressionNode(init) && init === node && babel.isIdentifier(id) ? id : null;
+}
+
+function constIdForInit(path: MutationPath): babel.Identifier | null {
+    const declaratorPath = path.parentPath;
+    const id = declaratorInitId(declaratorPath, path.node);
+
+    return id !== null && isNonExportedModuleConst(declaratorPath?.parentPath ?? null) ? id : null;
+}
+
+function isUnionCall(unionCallPath: MutationPath, bindings: ZodBindings): boolean {
+    const unionCall = unionCallPath.node;
+
+    return babel.isCallExpression(unionCall) && unionFactoryNames.has(getZodCallName(bindings, unionCall) ?? '');
+}
+
+function constIdForUnionOption(path: MutationPath, bindings: ZodBindings): babel.Identifier | null {
+    const optionsPath = path.parentPath;
+
+    if (optionsPath === null || !babel.isArrayExpression(optionsPath.node)) {
+        return null;
+    }
+
+    const unionCallPath = optionsPath.parentPath;
+
+    if (unionCallPath === null || !isUnionCall(unionCallPath, bindings)) {
+        return null;
+    }
+
+    return constIdForInit(unionCallPath);
+}
+
+function topLevelPathConstId(path: MutationPath, bindings: ZodBindings): babel.Identifier | null {
+    return constIdForInit(path) ?? constIdForUnionOption(path, bindings);
+}
+
+function childNodes(node: BabelNode): readonly BabelNode[] {
+    return Object.values(node).flatMap(function (value) {
+        if (Array.isArray(value)) {
+            return value.filter(babel.isNode);
+        }
+
+        return babel.isNode(value) ? [ value ] : [];
+    });
+}
+
+type IdentifierUse = {
+    readonly node: BabelNode;
+    readonly parent: BabelNode;
+    readonly grandparent: BabelNode | undefined;
+};
+
+function collectIdentifierUses(
+    node: BabelNode,
+    name: string,
+    ancestors: readonly BabelNode[]
+): readonly IdentifierUse[] {
+    const [ parent, grandparent ] = ancestors;
+    const here: readonly IdentifierUse[] = babel.isIdentifier(node) && node.name === name && parent !== undefined
+        ? [ { node, parent, grandparent } ]
+        : [];
+    const deeper = [ node, ...ancestors ];
+
+    return here.concat(
+        childNodes(node).flatMap(function (child) {
+            return collectIdentifierUses(child, name, deeper);
+        })
+    );
+}
+
+function isPropertyOrMemberName(use: IdentifierUse): boolean {
+    const { node, parent } = use;
+
+    if (babel.isObjectProperty(parent) || babel.isObjectMethod(parent)) {
+        return parent.key === node && !parent.computed;
+    }
+
+    return babel.isMemberExpression(parent) && parent.property === node && !parent.computed;
+}
+
+function isReference(use: IdentifierUse): boolean {
+    return babel.isReferenced(use.node, use.parent, use.grandparent);
+}
+
+function isForeignBinding(use: IdentifierUse, constIdNode: BabelNode): boolean {
+    return use.node !== constIdNode && !isReference(use) && !isPropertyOrMemberName(use);
+}
+
+function maskedAsWrapperArgument(
+    use: IdentifierUse,
+    maskingWrappers: ReadonlySet<string>,
+    bindings: ZodBindings
+): boolean {
+    const { node, parent } = use;
+
+    if (!babel.isCallExpression(parent)) {
+        return false;
+    }
+
+    const firstArgument = parent.arguments[0];
+
+    if (!isExpressionNode(firstArgument) || firstArgument !== node) {
+        return false;
+    }
+
+    return maskingWrappers.has(getZodCallName(bindings, parent) ?? '');
+}
+
+function maskedAsWrapperReceiver(use: IdentifierUse, maskingWrappers: ReadonlySet<string>): boolean {
+    const { node, parent, grandparent } = use;
+
+    if (!babel.isMemberExpression(parent) || parent.object !== node) {
+        return false;
+    }
+
+    if (!babel.isCallExpression(grandparent) || grandparent.callee !== parent) {
+        return false;
+    }
+
+    return maskingWrappers.has(getMemberName(parent) ?? '');
+}
+
+function isMaskedReference(use: IdentifierUse, maskingWrappers: ReadonlySet<string>, bindings: ZodBindings): boolean {
+    return maskedAsWrapperArgument(use, maskingWrappers, bindings) || maskedAsWrapperReceiver(use, maskingWrappers);
+}
+
+export function presenceWrapperMaskedByEveryUse(
+    path: MutationPath,
+    bindings: ZodBindings,
+    wrapperName: string
+): boolean {
+    const maskingWrappers = maskingWrappersByAddedWrapper.get(wrapperName);
+    const program = findProgram(path);
+    const constId = topLevelPathConstId(path, bindings);
+
+    if (maskingWrappers === undefined || program === null || constId === null) {
+        return false;
+    }
+
+    const uses = collectIdentifierUses(program, constId.name, []);
+    const references = uses.filter(isReference);
+    const hasForeignBinding = uses.some(function (use) {
+        return isForeignBinding(use, constId);
+    });
+    const allMasked = references.every(function (use) {
+        return isMaskedReference(use, maskingWrappers, bindings);
+    });
+
+    return !hasForeignBinding && references.length > 0 && allMasked;
+}

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -254,6 +254,113 @@ test('does not add a presence wrapper over a wrapped accept-anything schema', fu
     );
 });
 
+test('does not add a presence wrapper masked by every use of a module const', function () {
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const t = z.union([z.literal('w'), z.literal('b')]); export const s = z.nullable(t);",
+            'ZodNullableAdd'
+        ),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import { z } from 'zod/v4'; const t = z.union([z.literal('w'), z.literal('b')]); export const s = t.nullable();",
+            'ZodNullableAdd'
+        ),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const t = z.union([z.string()]); export const s = z.optional(t);",
+            'ZodOptionalAdd'
+        ),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const t = z.union([z.literal('w')]); const other = { t: 1 }; export const s = z.nullable(t);",
+            'ZodNullableAdd'
+        ),
+        []
+    );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const t = z.union([z.literal('w')]); const holder = {}; export const s = z.nullable(t); export const x = holder.t;",
+            'ZodNullableAdd'
+        ),
+        []
+    );
+});
+
+test('still mutates a const that is not masked by every use', function () {
+    const bareUse = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.union([z.literal('w'), z.literal('b')]); export const s = z.object({ c: z.nullable(t), d: t });",
+        'ZodNullableAdd'
+    );
+    const shadowed = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.union([z.literal('w')]); function read(t) { return t; } export const s = z.nullable(t);",
+        'ZodNullableAdd'
+    );
+    const noReference = collectMutations(
+        "import * as z from 'zod/mini'; export const t = z.union([z.literal('w'), z.literal('b')]);",
+        'ZodNullableAdd'
+    );
+    const nestedField = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.object({ a: z.literal('w') }); export const s = z.nullable(t);",
+        'ZodNullableAdd'
+    );
+    const arrayUse = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.literal('w'); export const s = z.array(t);",
+        'ZodNullableAdd'
+    );
+    const spreadOptions = collectMutations(
+        "import * as z from 'zod/mini'; const options = [ z.literal('w') ]; export const s = z.nullable(z.union(options));",
+        'ZodNullableAdd'
+    );
+    const memberUse = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.union([z.literal('w')]); export const shape = t.def; export const s = z.nullable(t);",
+        'ZodNullableAdd'
+    );
+    const mutableBinding = collectMutations(
+        "import * as z from 'zod/mini'; let t = z.union([z.literal('w')]); export const s = z.nullable(t);",
+        'ZodNullableAdd'
+    );
+    const tupleElement = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.tuple([z.literal('w')]); export const s = z.nullable(t);",
+        'ZodNullableAdd'
+    );
+    const recordValue = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.union([z.literal('w')]); export const s = z.record(z.string(), t);",
+        'ZodNullableAdd'
+    );
+    const destructuredBinding = collectMutations(
+        "import * as z from 'zod/mini'; const [ t ] = z.union([z.literal('w')]); export const s = z.nullable(t);",
+        'ZodNullableAdd'
+    );
+    const nonZodCallUse = collectMutations(
+        "import * as z from 'zod/mini'; const t = z.union([z.literal('w')]); export const s = wrapSchema(t);",
+        'ZodNullableAdd'
+    );
+    const exportedConst = collectMutations(
+        "import * as z from 'zod/mini'; export const t = z.union([z.literal('w')]); export const s = z.nullable(t);",
+        'ZodNullableAdd'
+    );
+
+    assert.ok(exportedConst.includes("z.nullable(z.union([z.literal('w')]))"));
+    assert.ok(nonZodCallUse.includes("z.nullable(z.union([z.literal('w')]))"));
+    assert.ok(destructuredBinding.includes("z.nullable(z.union([z.literal('w')]))"));
+    assert.ok(tupleElement.includes("z.nullable(z.literal('w'))"));
+    assert.ok(recordValue.includes("z.nullable(z.union([z.literal('w')]))"));
+    assert.ok(mutableBinding.includes("z.nullable(z.union([z.literal('w')]))"));
+    assert.ok(memberUse.includes("z.nullable(z.union([z.literal('w')]))"));
+    assert.ok(bareUse.includes("z.nullable(z.union([z.literal('w'), z.literal('b')]))"));
+    assert.ok(shadowed.includes("z.nullable(z.union([z.literal('w')]))"));
+    assert.ok(noReference.includes("z.nullable(z.union([z.literal('w'), z.literal('b')]))"));
+    assert.ok(nestedField.includes("z.nullable(z.literal('w'))"));
+    assert.ok(arrayUse.includes("z.nullable(z.literal('w'))"));
+    assert.ok(spreadOptions.includes("z.nullable(z.literal('w'))"));
+});
+
 test('does not re-wrap an already-optional or already-nullable object field', function () {
     assert.deepStrictEqual(
         collectMutations(

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -208,11 +208,16 @@ Boolean and string literal values are left to Stryker’s built-in literal mutat
 ## Limits
 
 This package monkeypatches Stryker internals because StrykerJS does not currently expose a custom mutator
-plugin API. It intentionally avoids cross-statement data-flow analysis and only mutates schema expressions
-that are visibly rooted in a detected Zod import.
+plugin API. It only mutates schema expressions that are visibly rooted in a detected Zod import.
 
-Because the equivalent-mutant checks are local to a single expression, a mutant can still be equivalent
-through a use-site elsewhere. For example a schema defined as `const s = z.union([...])` and consumed only
-as `z.nullable(s)` makes an added `nullable` inside `s` unobservable, but the added wrapper and the masking
-one live in different statements, so it is not detected here. Suppress such cases with a Stryker disable
-comment on the definition, or inline the schema at its use-site.
+The guiding rule for every operator: emit a mutant unless it can be _proven_ unkillable from the current
+module. A mutant we cannot prove equivalent is always emitted, even if it duplicates a wrapper already
+applied elsewhere. Suppressing a mutant that some test could kill is never acceptable.
+
+`ZodOptionalAdd` and `ZodNullableAdd` apply this with a module-local check: when the mutated node is the
+whole value of, or a `union`/`discriminatedUnion` branch of, a **non-exported** `const`, and every
+reference to that `const` in the module already applies the same wrapper (e.g. `const t = z.union([...])`
+used only as `z.nullable(t)`), no test can observe the added wrapper, so it is skipped. Because the `const`
+is not exported (nor re-exported via `export { t }` or `export default t`, both of which count as unmasked
+uses), every use is visible in the one module and the proof is sound. Exported consts, or any unmasked or
+unresolved reference, cause the mutant to be emitted.

--- a/source/stryker-zod-mutator/schema-call-mutations.ts
+++ b/source/stryker-zod-mutator/schema-call-mutations.ts
@@ -11,6 +11,7 @@ import {
     type SchemaExpression
 } from './ast.ts';
 import { callNode } from './mutation-definition.ts';
+import { presenceWrapperMaskedByEveryUse } from './masked-schema-references.ts';
 import {
     addingWrapperHasNoEffect,
     buildZodCall,
@@ -106,7 +107,8 @@ function shouldSkipWrapping(
     return !isSchemaValueChainRoot(path, bindings) ||
         wrapperAlreadyApplied(expression, name) ||
         addingWrapperHasNoEffect(bindings, expression, name) ||
-        isStringTemplateLiteralPart(path, bindings);
+        isStringTemplateLiteralPart(path, bindings) ||
+        presenceWrapperMaskedByEveryUse(path, bindings, name);
 }
 
 export function addWrapperOrMethod(


### PR DESCRIPTION
Closes Category 3 from the 0.0.7 report — a schema consumed only through a masking wrapper. Stacked on #487; base retargets to `main` once #487 merges.

Implements the general rule we agreed: **emit a mutant unless it can be proven unkillable from the current module; when in doubt, emit.** Suppressing a mutant some test could kill is never acceptable (it would give a false 100%); over-emitting a duplicate is an acceptable performance cost.

`ZodOptionalAdd`/`ZodNullableAdd`: when the mutated node is the whole value of, or a `union`/`discriminatedUnion` branch of, a **non-exported** module `const`, and every reference to that const in the module already applies the same wrapper (e.g. `const t = z.union([...])` used only as `z.nullable(t)`), no test can observe the added wrapper → skipped. This is a *proof*, not a heuristic, because a non-exported const's uses are all visible in the one module.

Escape routes are all treated as unmasked uses, so they correctly prevent the skip: exported declaration, `export { t }`, `export default t`, any bare/unmasked reference, or a reference we can't resolve. Exported consts are therefore always emitted (they can be imported and tested directly elsewhere).

Scope note vs the report: "adding `nullable` anywhere inside is unobservable" is only true on the top-level output path — a wrapper added to a nested object field or array element is *not* masked by an outer `z.nullable(...)`, so the analysis is restricted to the top-level path (whole schema / union branches), verified against Zod.

Reference resolution uses `@babel/types` `isReferenced` over a read-only `Program` walk — no new dependency, no traversal of Stryker's live AST. 540 tests pass, lint and coverage green.
