### PR TITLE
Resolve schema bindings, including across modules, before judging equivalence

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,15 @@
         "url": "git+https://github.com/enormora/schema-hub.git"
     },
     "dependencies": {
+        "@babel/parser": "8.0.4",
         "@babel/types": "8.0.4",
         "graphql": "17.0.2",
         "ky": "2.0.2",
-        "tslib": "2.8.1"
+        "tslib": "2.8.1",
+        "typescript": "6.0.3"
     },
     "devDependencies": {
         "@babel/generator": "8.0.0",
-        "@babel/parser": "8.0.4",
         "@enormora/eslint-config-base": "0.0.51",
         "@enormora/eslint-config-node": "0.0.37",
         "@enormora/eslint-config-typescript": "0.0.58",
@@ -36,7 +37,6 @@
         "rust-just": "1.55.1",
         "sinon": "22.0.0",
         "tstyche": "7.2.1",
-        "typescript": "6.0.3",
         "zod": "4.4.3"
     },
     "engines": {

--- a/source/stryker-zod-mutator/ast.ts
+++ b/source/stryker-zod-mutator/ast.ts
@@ -33,6 +33,26 @@ export function findProgram(path: MutationPath): babel.Program | null {
     return null;
 }
 
+function readProperty(value: unknown, key: string): unknown {
+    if (typeof value !== 'object' || value === null) {
+        return undefined;
+    }
+
+    return Reflect.get(value, key) as unknown;
+}
+
+function hubFileName(path: MutationPath): string | null {
+    const filename = readProperty(readProperty(readProperty(readProperty(path, 'hub'), 'file'), 'opts'), 'filename');
+
+    return typeof filename === 'string' ? filename : null;
+}
+
+export function fileNameOf(path: MutationPath): string | null {
+    const locationFileName = findProgram(path)?.loc?.filename;
+
+    return hubFileName(path) ?? (typeof locationFileName === 'string' ? locationFileName : null);
+}
+
 export function namedIdentifier(name: string): babel.Identifier {
     return babel.identifier(name);
 }

--- a/source/stryker-zod-mutator/binding-resolution.ts
+++ b/source/stryker-zod-mutator/binding-resolution.ts
@@ -1,0 +1,483 @@
+import * as babel from '@babel/types';
+import type { Node as BabelNode, Program } from '@babel/types';
+import { getMemberName, isExpressionNode, type CallExpression, type SchemaExpression } from './ast.ts';
+import {
+    buildZodBindings,
+    firstExpressionArgument,
+    getZodCallName,
+    valuePreservingWrapperNames,
+    type ZodBindings
+} from './zod-bindings.ts';
+
+export type ResolvedModule = {
+    readonly program: Program;
+    readonly fileName: string;
+};
+
+export type ResolverEnv = {
+    readonly loadModule: (specifier: string, fromFileName: string) => ResolvedModule | null;
+};
+
+export const inertResolverEnv: ResolverEnv = {
+    loadModule() {
+        return null;
+    }
+};
+
+type Resolution = {
+    readonly expression: SchemaExpression;
+    readonly bindings: ZodBindings;
+};
+
+type ResolveState = {
+    readonly bindings: ZodBindings;
+    readonly seen: ReadonlySet<string>;
+};
+
+type ResolveTarget =
+    | { readonly kind: 'exportName'; readonly name: string; }
+    | { readonly kind: 'expression'; readonly expression: SchemaExpression; }
+    | { readonly kind: 'localName'; readonly name: string; };
+
+type Recurse = (target: ResolveTarget, state: ResolveState) => Resolution | null;
+
+function seenKey(bindings: ZodBindings, name: string): string {
+    return `${bindings.fileName ?? ''} ${name}`;
+}
+
+function getPropertyName(property: Readonly<babel.ObjectProperty>): string | null {
+    if (babel.isIdentifier(property.key)) {
+        return property.key.name;
+    }
+
+    return babel.isStringLiteral(property.key) ? property.key.value : null;
+}
+
+function objectPropertyValue(object: Readonly<babel.ObjectExpression>, name: string): SchemaExpression | null {
+    const match = object.properties.find(function (property) {
+        return babel.isObjectProperty(property) && !property.computed && getPropertyName(property) === name;
+    });
+
+    return match !== undefined && babel.isObjectProperty(match) && isExpressionNode(match.value) ? match.value : null;
+}
+
+function propertySourceName(pattern: Readonly<babel.ObjectPattern>, localName: string): string {
+    const match = pattern.properties.find(function (property) {
+        return babel.isObjectProperty(property) && babel.isIdentifier(property.value) &&
+            property.value.name === localName;
+    });
+
+    return match !== undefined && babel.isObjectProperty(match) && !match.computed && babel.isIdentifier(match.key)
+        ? match.key.name
+        : localName;
+}
+
+function objectPatternValue(
+    pattern: Readonly<babel.ObjectPattern>,
+    name: string,
+    init: Resolution
+): SchemaExpression | null {
+    const holdsName = pattern.properties.some(function (property) {
+        return babel.isObjectProperty(property) && babel.isIdentifier(property.value) && property.value.name === name;
+    });
+
+    return holdsName && babel.isObjectExpression(init.expression)
+        ? objectPropertyValue(init.expression, propertySourceName(pattern, name))
+        : null;
+}
+
+function arrayPatternValue(
+    pattern: Readonly<babel.ArrayPattern>,
+    name: string,
+    init: Resolution
+): SchemaExpression | null {
+    const index = pattern.elements.findIndex(function (element) {
+        return babel.isIdentifier(element) && element.name === name;
+    });
+    const element = index !== -1 && babel.isArrayExpression(init.expression)
+        ? init.expression.elements[index]
+        : undefined;
+
+    return isExpressionNode(element) ? element : null;
+}
+
+function bindingPatternValue(id: BabelNode, name: string, init: Resolution): SchemaExpression | null {
+    if (babel.isObjectPattern(id)) {
+        return objectPatternValue(id, name, init);
+    }
+
+    return babel.isArrayPattern(id) ? arrayPatternValue(id, name, init) : null;
+}
+
+function patternBindsName(pattern: BabelNode, name: string): boolean {
+    if (babel.isObjectPattern(pattern)) {
+        return pattern.properties.some(function (property) {
+            return babel.isObjectProperty(property) && babel.isIdentifier(property.value) &&
+                property.value.name === name;
+        });
+    }
+
+    return babel.isArrayPattern(pattern) && pattern.elements.some(function (element) {
+        return babel.isIdentifier(element) && element.name === name;
+    });
+}
+
+function declaresName(declarator: Readonly<babel.VariableDeclarator>, name: string): boolean {
+    if (babel.isIdentifier(declarator.id)) {
+        return declarator.id.name === name;
+    }
+
+    return patternBindsName(declarator.id, name);
+}
+
+function localDeclarators(program: Program): readonly Readonly<babel.VariableDeclarator>[] {
+    return program.body.flatMap(function (statement) {
+        const declaration = babel.isExportNamedDeclaration(statement) ? statement.declaration : statement;
+
+        return babel.isVariableDeclaration(declaration) ? declaration.declarations : [];
+    });
+}
+
+type ImportBinding = {
+    readonly source: string;
+    readonly exportName: string;
+};
+
+type ImportSpecifierEntry = {
+    readonly specifier: Readonly<babel.ImportDeclaration['specifiers'][number]>;
+    readonly source: string;
+};
+
+function importSpecifierEntries(program: Program): readonly ImportSpecifierEntry[] {
+    return program.body.flatMap(function (statement) {
+        return babel.isImportDeclaration(statement)
+            ? statement.specifiers.map(function (specifier) {
+                return { specifier, source: statement.source.value };
+            })
+            : [];
+    });
+}
+
+function importedExportName(specifier: Readonly<babel.ImportDeclaration['specifiers'][number]>): string {
+    if (!babel.isImportSpecifier(specifier)) {
+        return 'default';
+    }
+
+    return babel.isIdentifier(specifier.imported) ? specifier.imported.name : specifier.imported.value;
+}
+
+function importBindingFor(program: Program, localName: string): ImportBinding | null {
+    const entry = importSpecifierEntries(program).find(function (candidate) {
+        return candidate.specifier.local.name === localName;
+    });
+
+    if (entry === undefined || babel.isImportNamespaceSpecifier(entry.specifier)) {
+        return null;
+    }
+
+    return { source: entry.source, exportName: importedExportName(entry.specifier) };
+}
+
+function defaultExportDeclaration(program: Program): SchemaExpression | null {
+    const [ declaration ] = program.body.flatMap(function (statement) {
+        return babel.isExportDefaultDeclaration(statement) ? [ statement.declaration ] : [];
+    });
+
+    return isExpressionNode(declaration) ? declaration : null;
+}
+
+function exportSpecifiers(program: Program): readonly Readonly<babel.ExportSpecifier>[] {
+    return program
+        .body
+        .flatMap(function (statement) {
+            return babel.isExportNamedDeclaration(statement) && statement.source === null ? statement.specifiers : [];
+        })
+        .flatMap(function (specifier) {
+            return babel.isExportSpecifier(specifier) ? [ specifier ] : [];
+        });
+}
+
+function exportedName(specifier: Readonly<babel.ExportSpecifier>): string {
+    return babel.isIdentifier(specifier.exported) ? specifier.exported.name : specifier.exported.value;
+}
+
+function localNameForExport(program: Program, exportName: string): string {
+    const specifier = exportSpecifiers(program).find(function (candidate) {
+        return exportedName(candidate) === exportName;
+    });
+
+    return specifier?.local.name ?? exportName;
+}
+
+function resolveMember(
+    member: Readonly<babel.MemberExpression>,
+    state: ResolveState,
+    recurse: Recurse
+): Resolution | null {
+    const name = getMemberName(member);
+
+    if (name === null || !isExpressionNode(member.object)) {
+        return null;
+    }
+
+    const object = recurse({ kind: 'expression', expression: member.object }, state);
+
+    if (object === null || !babel.isObjectExpression(object.expression)) {
+        return null;
+    }
+
+    const value = objectPropertyValue(object.expression, name);
+
+    return value === null
+        ? null
+        : recurse({ kind: 'expression', expression: value }, { bindings: object.bindings, seen: state.seen });
+}
+
+function resolveExpressionTarget(
+    expression: SchemaExpression,
+    state: ResolveState,
+    recurse: Recurse
+): Resolution | null {
+    if (babel.isIdentifier(expression)) {
+        return recurse({ kind: 'localName', name: expression.name }, state);
+    }
+
+    if (babel.isMemberExpression(expression)) {
+        return resolveMember(expression, state, recurse);
+    }
+
+    return { expression, bindings: state.bindings };
+}
+
+function declaratorValue(
+    declarator: Readonly<babel.VariableDeclarator>,
+    name: string,
+    state: ResolveState,
+    recurse: Recurse
+): Resolution | null {
+    if (!isExpressionNode(declarator.init)) {
+        return null;
+    }
+
+    const init = recurse({ kind: 'expression', expression: declarator.init }, state);
+
+    if (init === null || babel.isIdentifier(declarator.id) && declarator.id.name === name) {
+        return init;
+    }
+
+    const value = bindingPatternValue(declarator.id, name, init);
+
+    return value === null
+        ? null
+        : recurse({ kind: 'expression', expression: value }, { bindings: init.bindings, seen: state.seen });
+}
+
+function resolveLocalTarget(name: string, state: ResolveState, recurse: Recurse): Resolution | null {
+    const declarator = localDeclarators(state.bindings.program).find(function (candidate) {
+        return declaresName(candidate, name);
+    });
+
+    return declarator === undefined ? null : declaratorValue(declarator, name, state, recurse);
+}
+
+function resolveImportedTarget(name: string, state: ResolveState, recurse: Recurse): Resolution | null {
+    const binding = importBindingFor(state.bindings.program, name);
+
+    if (binding === null || state.bindings.fileName === null) {
+        return null;
+    }
+
+    const loaded = state.bindings.env.loadModule(binding.source, state.bindings.fileName);
+
+    if (loaded === null) {
+        return null;
+    }
+
+    const targetBindings = buildZodBindings(loaded.program, loaded.fileName, state.bindings.env);
+
+    return recurse({ kind: 'exportName', name: binding.exportName }, { bindings: targetBindings, seen: state.seen });
+}
+
+function resolveExportTarget(name: string, state: ResolveState, recurse: Recurse): Resolution | null {
+    if (name === 'default') {
+        const declaration = defaultExportDeclaration(state.bindings.program);
+
+        return declaration === null ? null : recurse({ kind: 'expression', expression: declaration }, state);
+    }
+
+    return recurse({ kind: 'localName', name: localNameForExport(state.bindings.program, name) }, state);
+}
+
+function resolveNameTarget(name: string, state: ResolveState, recurse: Recurse): Resolution | null {
+    const key = seenKey(state.bindings, name);
+
+    if (state.seen.has(key)) {
+        return null;
+    }
+
+    const next: ResolveState = { bindings: state.bindings, seen: new Set([ ...state.seen, key ]) };
+
+    return resolveLocalTarget(name, next, recurse) ?? resolveImportedTarget(name, next, recurse);
+}
+
+function resolve(target: ResolveTarget, state: ResolveState): Resolution | null {
+    if (target.kind === 'expression') {
+        return resolveExpressionTarget(target.expression, state, resolve);
+    }
+
+    if (target.kind === 'exportName') {
+        return resolveExportTarget(target.name, state, resolve);
+    }
+
+    return resolveNameTarget(target.name, state, resolve);
+}
+
+function resolveSchemaReference(bindings: ZodBindings, name: string): Resolution | null {
+    return resolve({ kind: 'localName', name }, { bindings, seen: new Set() });
+}
+
+function resolveExpressionReference(bindings: ZodBindings, expression: SchemaExpression): Resolution | null {
+    return resolve({ kind: 'expression', expression }, { bindings, seen: new Set() });
+}
+
+type ChainStep = {
+    readonly node: CallExpression;
+    readonly bindings: ZodBindings;
+};
+
+const freezableSchemaFactoryNames = new Set([
+    'object',
+    'strictObject',
+    'looseObject',
+    'array',
+    'tuple',
+    'record',
+    'partialRecord',
+    'looseRecord'
+]);
+
+function underlyingSchemaExpression(bindings: ZodBindings, call: CallExpression): SchemaExpression | null {
+    const callName = getZodCallName(bindings, call);
+
+    if (callName !== null && valuePreservingWrapperNames.has(callName)) {
+        return firstExpressionArgument(call);
+    }
+
+    return babel.isMemberExpression(call.callee) && isExpressionNode(call.callee.object)
+        ? call.callee.object
+        : null;
+}
+
+function stepFromNode(node: SchemaExpression, bindings: ZodBindings): Resolution | null {
+    if (babel.isIdentifier(node)) {
+        return resolveSchemaReference(bindings, node.name);
+    }
+
+    if (babel.isMemberExpression(node) && !babel.isCallExpression(node)) {
+        const resolved = resolveExpressionReference(bindings, node);
+
+        return resolved === null || babel.isMemberExpression(resolved.expression) ? null : resolved;
+    }
+
+    return { expression: node, bindings };
+}
+
+function nextResolution(step: Resolution): Resolution | null {
+    const node: SchemaExpression = step.expression;
+
+    if (!babel.isCallExpression(node)) {
+        return stepFromNode(node, step.bindings);
+    }
+
+    const next = underlyingSchemaExpression(step.bindings, node);
+
+    return next === null ? null : stepFromNode(next, step.bindings);
+}
+
+function* schemaChain(expression: SchemaExpression, bindings: ZodBindings): Generator<ChainStep> {
+    const seen = new Set<BabelNode>();
+    let resolution: Resolution | null = { expression, bindings };
+
+    while (resolution !== null && !seen.has(resolution.expression)) {
+        seen.add(resolution.expression);
+
+        if (babel.isCallExpression(resolution.expression)) {
+            yield { node: resolution.expression, bindings: resolution.bindings };
+        }
+
+        resolution = nextResolution(resolution);
+    }
+}
+
+function isFreezableFactoryCall(step: ChainStep): boolean {
+    const callName = getZodCallName(step.bindings, step.node);
+
+    return callName !== null && freezableSchemaFactoryNames.has(callName);
+}
+
+export function producesFreezableValue(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    return Array.from(schemaChain(expression, bindings)).some(isFreezableFactoryCall);
+}
+
+function appliesReadonly(step: ChainStep): boolean {
+    return getZodCallName(step.bindings, step.node) === 'readonly' || getMemberName(step.node.callee) === 'readonly';
+}
+
+export function chainAppliesReadonly(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    return Array.from(schemaChain(expression, bindings)).some(appliesReadonly);
+}
+
+const acceptAnythingFactoryNames = new Set([ 'any', 'unknown' ]);
+
+function schemaName(step: ChainStep): string {
+    return getZodCallName(step.bindings, step.node) ?? getMemberName(step.node.callee) ?? '';
+}
+
+function isBreakingWrapper(step: ChainStep): boolean {
+    return !valuePreservingWrapperNames.has(schemaName(step));
+}
+
+export function resolvesToAcceptAnything(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    const steps = Array.from(schemaChain(expression, bindings));
+    const decisive = steps.find(function (step) {
+        return acceptAnythingFactoryNames.has(schemaName(step)) || isBreakingWrapper(step);
+    });
+
+    return decisive !== undefined && acceptAnythingFactoryNames.has(schemaName(decisive));
+}
+
+const factoryNamesAcceptingUndefined = new Set([
+    'any',
+    'unknown',
+    'undefined',
+    'void',
+    'nullish',
+    'prefault',
+    'default',
+    '_default'
+]);
+const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null', 'nullish' ]);
+
+const alreadyAcceptedValueByWrapper = new Map<string, ReadonlySet<string>>([
+    [ 'optional', factoryNamesAcceptingUndefined ],
+    [ 'nullable', factoryNamesAcceptingNull ]
+]);
+
+export function addingWrapperHasNoEffect(
+    bindings: ZodBindings,
+    expression: SchemaExpression,
+    wrapperName: string
+): boolean {
+    const acceptingFactories = alreadyAcceptedValueByWrapper.get(wrapperName);
+    const [ outer ] = Array.from(schemaChain(expression, bindings));
+
+    if (acceptingFactories === undefined || outer === undefined) {
+        return false;
+    }
+
+    const outerName = schemaName(outer);
+
+    return outerName === wrapperName ||
+        acceptingFactories.has(outerName) ||
+        resolvesToAcceptAnything(bindings, expression);
+}

--- a/source/stryker-zod-mutator/filesystem-module-loader.test.ts
+++ b/source/stryker-zod-mutator/filesystem-module-loader.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { generate } from '@babel/generator';
+import { parse } from '@babel/parser';
+import { isNode, VISITOR_KEYS, type Node as BabelNode } from '@babel/types';
+import { test } from '@sondr3/minitest';
+import { createZodMutators } from './mutations.ts';
+import type { MutationPath } from './ast.ts';
+
+function childNodes(node: BabelNode): readonly BabelNode[] {
+    return (VISITOR_KEYS[node.type] ?? []).flatMap(function (key) {
+        const value = node[key as keyof BabelNode] as unknown;
+
+        if (Array.isArray(value)) {
+            return value.filter(isNode);
+        }
+
+        return isNode(value) ? [ value ] : [];
+    });
+}
+
+function eachPath(node: BabelNode, parentPath: MutationPath | null, visit: (path: MutationPath) => void): void {
+    const mutationPath = { node, parentPath };
+    visit(mutationPath);
+
+    for (const child of childNodes(node)) {
+        eachPath(child, mutationPath, visit);
+    }
+}
+
+function writeModules(files: Readonly<Record<string, string>>): string {
+    const directory = join(tmpdir(), `zod-mutator-${process.hrtime.bigint().toString()}`);
+    ts.sys.createDirectory(directory);
+
+    for (const [ name, content ] of Object.entries(files)) {
+        ts.sys.writeFile(join(directory, name), content);
+    }
+
+    return directory;
+}
+
+function collectFilesystemReadonlyAdds(
+    entrySource: string,
+    files: Readonly<Record<string, string>>
+): readonly string[] {
+    const directory = writeModules(files);
+    const entryPath = join(directory, 'entry.ts');
+    ts.sys.writeFile(entryPath, entrySource);
+
+    const { program } = parse(entrySource, {
+        plugins: [ 'typescript', 'jsx' ],
+        sourceType: 'module',
+        sourceFilename: entryPath
+    });
+    const mutator = createZodMutators([ 'ZodReadonlyAdd' ])[0];
+    const mutations: string[] = [];
+
+    if (mutator === undefined) {
+        assert.fail('Could not find ZodReadonlyAdd');
+    }
+
+    eachPath(program, null, function (path) {
+        for (const mutation of mutator.mutate(path)) {
+            mutations.push(generate(mutation).code);
+        }
+    });
+
+    return Array.from(new Set(mutations));
+}
+
+test('resolves schema bindings across real modules on disk', function () {
+    const mutations = collectFilesystemReadonlyAdds(
+        "import { z } from 'zod/v4';\nimport { fields } from './fields.ts';\nexport const schema = z.optional(fields);\n",
+        { 'fields.ts': "import { z } from 'zod/v4';\nexport const fields = z.object({ id: z.string() });\n" }
+    );
+
+    assert.ok(mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('resolves schema bindings using a discovered tsconfig on disk', function () {
+    const mutations = collectFilesystemReadonlyAdds(
+        "import { z } from 'zod/v4';\nimport { fields } from './fields.ts';\nexport const schema = z.optional(fields);\n",
+        {
+            'tsconfig.json': '{ "compilerOptions": { "module": "node16", "moduleResolution": "node16" } }',
+            'fields.ts': "import { z } from 'zod/v4';\nexport const fields = z.object({ id: z.string() });\n"
+        }
+    );
+
+    assert.ok(mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('bails to emitting when a real module cannot be resolved or parsed', function () {
+    const unresolved = collectFilesystemReadonlyAdds(
+        "import { z } from 'zod/v4';\nimport { fields } from './absent.ts';\nexport const schema = z.optional(fields);\n",
+        {}
+    );
+    const broken = collectFilesystemReadonlyAdds(
+        "import { z } from 'zod/v4';\nimport { fields } from './broken.ts';\nexport const schema = z.optional(fields);\n",
+        { 'broken.ts': 'this is (not valid typescript' }
+    );
+    const packaged = collectFilesystemReadonlyAdds(
+        "import { z } from 'zod/v4';\nimport { types } from '@babel/types';\nexport const schema = z.optional(types);\n",
+        {}
+    );
+
+    assert.ok(!unresolved.includes('z.optional(fields).readonly()'));
+    assert.ok(!broken.includes('z.optional(fields).readonly()'));
+    assert.ok(!packaged.includes('z.optional(types).readonly()'));
+});
+
+test('resolves modules even when a discovered tsconfig is unreadable', function () {
+    const mutations = collectFilesystemReadonlyAdds(
+        "import { z } from 'zod/v4';\nimport { fields } from './fields.ts';\nexport const schema = z.optional(fields);\n",
+        {
+            'tsconfig.json': 'not valid json {',
+            'fields.ts': "import { z } from 'zod/v4';\nexport const fields = z.object({ id: z.string() });\n"
+        }
+    );
+
+    assert.ok(Array.isArray(mutations));
+});

--- a/source/stryker-zod-mutator/filesystem-module-loader.ts
+++ b/source/stryker-zod-mutator/filesystem-module-loader.ts
@@ -1,0 +1,95 @@
+import { dirname } from 'node:path';
+import ts from 'typescript';
+import { parse } from '@babel/parser';
+import type { Program } from '@babel/types';
+import type { ResolvedModule, ResolverEnv } from './binding-resolution.ts';
+
+const babelPlugins: readonly ('jsx' | 'typescript')[] = [ 'typescript', 'jsx' ];
+
+const fallbackCompilerOptions: Readonly<ts.CompilerOptions> = {
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    allowImportingTsExtensions: true,
+    allowJs: true
+};
+
+const programCache = new Map<string, Program | null>();
+const resolutionCache = new Map<string, string | null>();
+const compilerOptionsCache = new Map<string, Readonly<ts.CompilerOptions>>();
+
+function parseProgram(source: string, fileName: string): Program | null {
+    try {
+        return parse(source, { sourceType: 'module', plugins: Array.from(babelPlugins), sourceFilename: fileName })
+            .program;
+    } catch {
+        return null;
+    }
+}
+
+function readAndParse(absolutePath: string): Program | null {
+    const source = ts.sys.readFile(absolutePath);
+
+    return source === undefined ? null : parseProgram(source, absolutePath);
+}
+
+function loadProgram(absolutePath: string): Program | null {
+    if (!programCache.has(absolutePath)) {
+        programCache.set(absolutePath, readAndParse(absolutePath));
+    }
+
+    return programCache.get(absolutePath) ?? null;
+}
+
+function readCompilerOptions(configPath: string): Readonly<ts.CompilerOptions> {
+    if (configPath === '') {
+        return fallbackCompilerOptions;
+    }
+
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+    const parsed = ts.parseJsonConfigFileContent(configFile.config ?? {}, ts.sys, dirname(configPath));
+
+    return parsed.options;
+}
+
+function compilerOptionsFor(fromFileName: string): Readonly<ts.CompilerOptions> {
+    const configPath = ts.findConfigFile(dirname(fromFileName), ts.sys.fileExists) ?? '';
+    const cached = compilerOptionsCache.get(configPath);
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const options = readCompilerOptions(configPath);
+    compilerOptionsCache.set(configPath, options);
+
+    return options;
+}
+
+function isProjectSource(fileName: string): boolean {
+    return !fileName.includes('/node_modules/') && !fileName.endsWith('.d.ts');
+}
+
+function resolveOnce(specifier: string, fromFileName: string): string | null {
+    const result = ts.resolveModuleName(specifier, fromFileName, compilerOptionsFor(fromFileName), ts.sys);
+    const resolved = result.resolvedModule?.resolvedFileName;
+
+    return resolved !== undefined && isProjectSource(resolved) ? resolved : null;
+}
+
+function resolveModulePath(specifier: string, fromFileName: string): string | null {
+    const key = `${fromFileName}\n${specifier}`;
+
+    if (!resolutionCache.has(key)) {
+        resolutionCache.set(key, resolveOnce(specifier, fromFileName));
+    }
+
+    return resolutionCache.get(key) ?? null;
+}
+
+function loadModule(specifier: string, fromFileName: string): ResolvedModule | null {
+    const resolved = resolveModulePath(specifier, fromFileName);
+    const program = resolved === null ? null : loadProgram(resolved);
+
+    return program === null || resolved === null ? null : { program, fileName: resolved };
+}
+
+export const filesystemResolverEnv: ResolverEnv = { loadModule };

--- a/source/stryker-zod-mutator/mutation-definition.ts
+++ b/source/stryker-zod-mutator/mutation-definition.ts
@@ -3,6 +3,7 @@ import type { Node as BabelNode } from '@babel/types';
 import type { CallExpression, MutationPath } from './ast.ts';
 import type { ZodMutationOperator } from './operator.ts';
 import { readZodBindings, type ZodBindings } from './zod-bindings.ts';
+import type { ResolverEnv } from './binding-resolution.ts';
 
 export type ZodMutator = {
     readonly name: ZodMutationOperator;
@@ -25,11 +26,11 @@ export function callNode(path: MutationPath): CallExpression | null {
     return babel.isCallExpression(path.node) ? path.node : null;
 }
 
-export function createZodMutator(definition: MutationDefinition): ZodMutator {
+export function createZodMutator(definition: MutationDefinition, env: ResolverEnv): ZodMutator {
     return {
         name: definition.name,
         mutate(path: MutationPath): Iterable<BabelNode> {
-            return definition.mutate(path, readZodBindings(path));
+            return definition.mutate(path, readZodBindings(path, env));
         }
     };
 }

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -9,13 +9,14 @@ import {
     withZodMutators,
     type ZodMutatorSettings
 } from './entry-point.ts';
-import { createZodMutators } from './mutations.ts';
+import { createZodMutators, createZodMutatorsWithResolver } from './mutations.ts';
 import {
     zodMutationCategories,
     zodMutationOperators,
     type ZodMutationOperator
 } from './operator.ts';
-import type { MutationPath } from './ast.ts';
+import { fileNameOf, type MutationPath } from './ast.ts';
+import { inertResolverEnv, type ResolvedModule, type ResolverEnv } from './binding-resolution.ts';
 
 type StrykerMutatorRegistry = {
     readonly allMutators: readonly { readonly name: string; }[];
@@ -79,6 +80,48 @@ function assertIncludesMutation(testCase: OperatorCase): void {
         mutations.includes(testCase.expected),
         `${testCase.operator} did not include ${testCase.expected}. Found ${JSON.stringify(mutations)}`
     );
+}
+
+function parseModule(source: string, fileName: string): ReturnType<typeof parse>['program'] {
+    return parse(source, { plugins: [ 'typescript', 'jsx' ], sourceType: 'module', sourceFilename: fileName }).program;
+}
+
+function moduleResolverEnv(modules: Readonly<Record<string, string>>): ResolverEnv {
+    return {
+        loadModule(specifier: string): ResolvedModule | null {
+            const source = modules[specifier];
+
+            if (source === undefined) {
+                return null;
+            }
+
+            const fileName = `/virtual/${specifier}.ts`;
+
+            return { program: parseModule(source, fileName), fileName };
+        }
+    };
+}
+
+function collectResolvedMutations(
+    source: string,
+    operator: ZodMutationOperator,
+    env: ResolverEnv
+): readonly string[] {
+    const program = parseModule(source, '/virtual/entry.ts');
+    const mutator = createZodMutatorsWithResolver([ operator ], env)[0];
+    const mutations: string[] = [];
+
+    if (mutator === undefined) {
+        assert.fail(`Could not find ${operator}`);
+    }
+
+    visitAst(program, null, function (path) {
+        for (const mutation of mutator.mutate(path)) {
+            mutations.push(generate(mutation).code);
+        }
+    });
+
+    return unique(mutations);
 }
 
 async function readStrykerMutatorNames(): Promise<readonly string[]> {
@@ -1206,4 +1249,285 @@ test('patches Stryker mutators with selected operators once', async function () 
 
     assert.strictEqual(optionalAddCount, 1);
     assert.ok(names.includes('ZodCoercionRemove'));
+});
+
+test('adds readonly through an aliased freezable schema binding', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const fields = z.object({ id: z.string() }); const schema = z.optional(fields);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('adds readonly through a member-access schema binding', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const shapes = { user: z.object({ id: z.string() }) }; const schema = z.optional(shapes.user);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(mutations.includes('z.optional(shapes.user).readonly()'));
+});
+
+test('adds readonly through a destructured schema binding', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const { user } = { user: z.object({ id: z.string() }) }; const schema = z.optional(user);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(mutations.includes('z.optional(user).readonly()'));
+});
+
+test('adds readonly through an alias chain of schema bindings', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const base = z.object({ id: z.string() }); const alias = base; const schema = z.optional(alias);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(mutations.includes('z.optional(alias).readonly()'));
+});
+
+test('skips an optional wrapper that a binding proves has no effect', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const loose = z.any(); const schema = z.nullable(loose);",
+        'ZodOptionalAdd'
+    );
+
+    assert.ok(!mutations.includes('z.nullable(loose).optional()'));
+});
+
+test('still adds a wrapper when a binding resolves to a distinguishable schema', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const inner = z.string(); const schema = z.nullable(inner);",
+        'ZodOptionalAdd'
+    );
+
+    assert.ok(mutations.includes('z.nullable(inner).optional()'));
+});
+
+test('does not add readonly when a binding resolves to a non-freezable schema', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const inner = z.string(); const schema = z.optional(inner);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(inner).readonly()'));
+});
+
+test('does not add readonly when a binding resolves to a non-schema value', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const label = 'plain'; const schema = z.optional(label);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('adds readonly through a schema binding imported from another module', function () {
+    const env = moduleResolverEnv({
+        './fields': "import { z } from 'zod/v4'; export const fields = z.object({ id: z.string() });"
+    });
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import { fields } from './fields'; const schema = z.optional(fields);",
+        'ZodReadonlyAdd',
+        env
+    );
+
+    assert.ok(mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('follows an aliased export name across a module boundary', function () {
+    const env = moduleResolverEnv({
+        './fields': "import { z } from 'zod/v4'; const base = z.object({ id: z.string() }); export { base as fields };"
+    });
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import { fields } from './fields'; const schema = z.optional(fields);",
+        'ZodReadonlyAdd',
+        env
+    );
+
+    assert.ok(mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('follows a default import across a module boundary', function () {
+    const env = moduleResolverEnv({
+        './fields': "import { z } from 'zod/v4'; const fields = z.object({ id: z.string() }); export default fields;"
+    });
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import fields from './fields'; const schema = z.optional(fields);",
+        'ZodReadonlyAdd',
+        env
+    );
+
+    assert.ok(mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('emits the wrapper when a cross-module binding cannot be resolved', function () {
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import { missing } from './absent'; const schema = z.nullable(missing);",
+        'ZodOptionalAdd',
+        moduleResolverEnv({})
+    );
+
+    assert.ok(mutations.includes('z.nullable(missing).optional()'));
+});
+
+test('ignores a namespace import used as a schema reference', function () {
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import * as shapes from './shapes'; const schema = z.optional(shapes);",
+        'ZodReadonlyAdd',
+        moduleResolverEnv({ './shapes': "import { z } from 'zod/v4'; export const a = z.object({});" })
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('adds readonly through an array-destructured schema binding', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const [ first ] = [ z.object({ id: z.string() }) ]; const schema = z.optional(first);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(mutations.includes('z.optional(first).readonly()'));
+});
+
+test('resolves a quoted object property key', function () {
+    const mutations = collectMutations(
+        'import { z } from \'zod/v4\'; const shapes = { "user": z.object({ id: z.string() }) }; const schema = z.optional(shapes.user);',
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(mutations.includes('z.optional(shapes.user).readonly()'));
+});
+
+test('does not resolve a missing object property', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const shapes = { user: z.object({}) }; const schema = z.optional(shapes.missing);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(shapes.missing).readonly()'));
+});
+
+test('stops at a self-referential binding cycle', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const a = b; const b = a; const schema = z.optional(a);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('does not resolve cross-module bindings with an inert resolver', function () {
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import { fields } from './fields'; const schema = z.optional(fields);",
+        'ZodReadonlyAdd',
+        inertResolverEnv
+    );
+
+    assert.ok(!mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('does not resolve imported bindings when the current file name is unknown', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; import { fields } from './fields'; const schema = z.optional(fields);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('bails when a default import has no matching default export', function () {
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import fields from './fields'; const schema = z.optional(fields);",
+        'ZodReadonlyAdd',
+        moduleResolverEnv({ './fields': "import { z } from 'zod/v4'; export const other = z.object({});" })
+    );
+
+    assert.ok(!mutations.includes('z.optional(fields).readonly()'));
+});
+
+test('resolves a member binding past a non-identifier sibling key', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const shapes = { 1: z.number(), user: z.object({ id: z.string() }) }; const schema = z.optional(shapes.user);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(mutations.includes('z.optional(shapes.user).readonly()'));
+});
+
+test('does not resolve an object destructure over a non-object initializer', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const { user } = z.string(); const schema = z.optional(user);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(user).readonly()'));
+});
+
+test('does not resolve an array destructure over a non-array initializer', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const [ first ] = z.string(); const schema = z.optional(first);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(first).readonly()'));
+});
+
+test('reads the current file name from a Stryker node path hub', function () {
+    const hubPath = { node: identifier('x'), parentPath: null, hub: { file: { opts: { filename: '/module.ts' } } } };
+
+    assert.strictEqual(fileNameOf(hubPath), '/module.ts');
+});
+
+test('follows a string-literal import name across a module boundary', function () {
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import { 'fields' as f } from './fields'; const schema = z.optional(f);",
+        'ZodReadonlyAdd',
+        moduleResolverEnv({
+            './fields': "import { z } from 'zod/v4'; export const fields = z.object({ id: z.string() });"
+        })
+    );
+
+    assert.ok(mutations.includes('z.optional(f).readonly()'));
+});
+
+test('does not resolve a computed member access', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const key = 'user'; const shapes = { user: z.object({}) }; const schema = z.optional(shapes[key]);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(shapes[key]).readonly()'));
+});
+
+test('does not resolve a binding declared without an initializer', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; let holder; const schema = z.optional(holder);",
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(holder).readonly()'));
+});
+
+test('does not resolve a destructure with a renamed string-literal key', function () {
+    const mutations = collectMutations(
+        'import { z } from \'zod/v4\'; const { "id": user } = { id: z.object({}) }; const schema = z.optional(user);',
+        'ZodReadonlyAdd'
+    );
+
+    assert.ok(!mutations.includes('z.optional(user).readonly()'));
+});
+
+test('follows a string-literal export name across a module boundary', function () {
+    const mutations = collectResolvedMutations(
+        "import { z } from 'zod/v4'; import { fields } from './fields'; const schema = z.optional(fields);",
+        'ZodReadonlyAdd',
+        moduleResolverEnv({
+            './fields':
+                "import { z } from 'zod/v4'; const base = z.object({ id: z.string() }); export { base as 'fields' };"
+        })
+    );
+
+    assert.ok(mutations.includes('z.optional(fields).readonly()'));
 });

--- a/source/stryker-zod-mutator/mutations.ts
+++ b/source/stryker-zod-mutator/mutations.ts
@@ -10,6 +10,8 @@ import { objectMutationDefinitions } from './object-mutations.ts';
 import type { ZodMutationOperator } from './operator.ts';
 import { presenceMutationDefinitions } from './presence-mutations.ts';
 import { primitiveMutationDefinitions } from './primitive-mutations.ts';
+import type { ResolverEnv } from './binding-resolution.ts';
+import { filesystemResolverEnv } from './filesystem-module-loader.ts';
 
 const mutationDefinitions: readonly MutationDefinition[] = [
     ...primitiveMutationDefinitions,
@@ -20,12 +22,21 @@ const mutationDefinitions: readonly MutationDefinition[] = [
     ...behaviorMutationDefinitions
 ];
 
-export function createZodMutators(operators: readonly ZodMutationOperator[]): readonly ZodMutator[] {
+export function createZodMutatorsWithResolver(
+    operators: readonly ZodMutationOperator[],
+    env: ResolverEnv
+): readonly ZodMutator[] {
     const selectedOperators = new Set(operators);
 
     return mutationDefinitions
         .filter(function (definition) {
             return selectedOperators.has(definition.name);
         })
-        .map(createZodMutator);
+        .map(function (definition) {
+            return createZodMutator(definition, env);
+        });
+}
+
+export function createZodMutators(operators: readonly ZodMutationOperator[]): readonly ZodMutator[] {
+    return createZodMutatorsWithResolver(operators, filesystemResolverEnv);
 }

--- a/source/stryker-zod-mutator/object-mutations.ts
+++ b/source/stryker-zod-mutator/object-mutations.ts
@@ -12,7 +12,6 @@ import {
 } from './ast.ts';
 import { callNode, createDefinition, type MutationDefinition } from './mutation-definition.ts';
 import {
-    addingWrapperHasNoEffect,
     buildZodCall,
     expressionStyle,
     getZodCallName,
@@ -22,6 +21,7 @@ import {
     type ZodApiStyle,
     type ZodBindings
 } from './zod-bindings.ts';
+import { addingWrapperHasNoEffect } from './binding-resolution.ts';
 import { removeMethodOrWrapper } from './schema-call-mutations.ts';
 
 function mutateObjectFactory(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {

--- a/source/stryker-zod-mutator/presence-mutations.ts
+++ b/source/stryker-zod-mutator/presence-mutations.ts
@@ -6,13 +6,12 @@ import {
 } from './schema-call-mutations.ts';
 import { isExpressionNode, type MutationPath } from './ast.ts';
 import { createDefinition, type MutationDefinition } from './mutation-definition.ts';
+import { isSchemaValueChainRoot, type ZodBindings } from './zod-bindings.ts';
 import {
     addingWrapperHasNoEffect,
     chainAppliesReadonly,
-    isSchemaValueChainRoot,
-    producesFreezableValue,
-    type ZodBindings
-} from './zod-bindings.ts';
+    producesFreezableValue
+} from './binding-resolution.ts';
 
 function addReadonlyToFreezableSchema(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
     if (!isExpressionNode(path.node) || !isSchemaValueChainRoot(path, bindings)) {

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -221,3 +221,21 @@ used only as `z.nullable(t)`), no test can observe the added wrapper, so it is s
 is not exported (nor re-exported via `export { t }` or `export default t`, both of which count as unmasked
 uses), every use is visible in the one module and the proof is sound. Exported consts, or any unmasked or
 unresolved reference, cause the mutant to be emitted.
+
+## Binding resolution
+
+Deciding whether a mutant is equivalent often needs the schema's real shape, which is not always written
+inline. When an operator reaches a reference instead of a schema call (for example `z.optional(user)` where
+`user` is a `const`), it resolves that reference back to its definition and continues the analysis there.
+Resolution follows aliases (`const t = other`), object and array destructuring (`const { t } = shapes`),
+member access into object literals (`const t = shapes.user`), and imports, including across modules: an
+imported name is resolved by loading the source module, mapping the export back to its local definition
+(named, aliased, or default), and recursing.
+
+Cross-module resolution reads and parses the imported file. Module specifiers are resolved with the
+TypeScript compiler API using the nearest discovered `tsconfig.json`, so `paths`, `baseUrl`, and extension
+rewriting behave as they do in the project. This stays faithful to the guiding rule: anything that cannot
+be resolved (a missing file, a `paths` alias with no matching config, a reference that turns out not to be
+a schema, or a namespace import) is treated as unknown and the mutant is emitted rather than suppressed.
+Only same-module (`export`) analysis is complete; a schema imported elsewhere and tested there is never
+assumed unkillable.

--- a/source/stryker-zod-mutator/registry-and-bindings.test.ts
+++ b/source/stryker-zod-mutator/registry-and-bindings.test.ts
@@ -3,6 +3,7 @@ import {
     callExpression,
     identifier,
     memberExpression,
+    program,
     stringLiteral
 } from '@babel/types';
 import { test } from '@sondr3/minitest';
@@ -16,11 +17,21 @@ import {
     replaceZodCallee,
     type ZodBindings
 } from './zod-bindings.ts';
+import { inertResolverEnv } from './binding-resolution.ts';
 
-const emptyBindings: ZodBindings = { namespaces: [], directBindings: [] };
+const emptyBindings: ZodBindings = {
+    namespaces: [],
+    directBindings: [],
+    program: program([]),
+    fileName: null,
+    env: inertResolverEnv
+};
 const classicBindings: ZodBindings = {
     namespaces: [ { name: 'z', style: 'classic' } ],
-    directBindings: [ { localName: 'text', importedName: 'string', style: 'mini' } ]
+    directBindings: [ { localName: 'text', importedName: 'string', style: 'mini' } ],
+    program: program([]),
+    fileName: null,
+    env: inertResolverEnv
 };
 
 test('exposes Zod binding fallbacks without mutating unknown calls', function () {

--- a/source/stryker-zod-mutator/schema-call-mutations.ts
+++ b/source/stryker-zod-mutator/schema-call-mutations.ts
@@ -13,7 +13,6 @@ import {
 import { callNode } from './mutation-definition.ts';
 import { presenceWrapperMaskedByEveryUse } from './masked-schema-references.ts';
 import {
-    addingWrapperHasNoEffect,
     buildZodCall,
     expressionStyle,
     firstExpressionArgument,
@@ -24,6 +23,7 @@ import {
     type ZodApiStyle,
     type ZodBindings
 } from './zod-bindings.ts';
+import { addingWrapperHasNoEffect } from './binding-resolution.ts';
 
 export function removeMethod(
     call: CallExpression,

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -1,6 +1,7 @@
 import * as babel from '@babel/types';
-import type { Node as BabelNode } from '@babel/types';
+import type { Node as BabelNode, Program } from '@babel/types';
 import {
+    fileNameOf,
     findProgram,
     getMemberName,
     isExpressionNode,
@@ -8,6 +9,7 @@ import {
     type MutationPath,
     type SchemaExpression
 } from './ast.ts';
+import type { ResolverEnv } from './binding-resolution.ts';
 
 export type ZodApiStyle = 'classic' | 'mini';
 
@@ -35,6 +37,9 @@ type SourceStatement = Readonly<babel.Statement>;
 export type ZodBindings = {
     readonly namespaces: readonly NamespaceBinding[];
     readonly directBindings: readonly DirectBinding[];
+    readonly program: Program;
+    readonly fileName: string | null;
+    readonly env: ResolverEnv;
 };
 
 const zodSourceStyles = new Map<string, ZodApiStyle>([
@@ -142,9 +147,8 @@ function readZodImport(statement: SourceStatement): ZodImportBindings {
     };
 }
 
-export function readZodBindings(path: MutationPath): ZodBindings {
-    const program = findProgram(path);
-    const imports = program?.body.map(readZodImport) ?? [];
+export function buildZodBindings(program: Program, fileName: string | null, env: ResolverEnv): ZodBindings {
+    const imports = program.body.map(readZodImport);
 
     return {
         namespaces: imports.flatMap(function (binding) {
@@ -152,8 +156,15 @@ export function readZodBindings(path: MutationPath): ZodBindings {
         }),
         directBindings: imports.flatMap(function (binding) {
             return binding.directBindings;
-        })
+        }),
+        program,
+        fileName,
+        env
     };
+}
+
+export function readZodBindings(path: MutationPath, env: ResolverEnv): ZodBindings {
+    return buildZodBindings(findProgram(path) ?? babel.program([]), fileNameOf(path), env);
 }
 
 export function getDirectBinding(bindings: ZodBindings, localName: string): DirectBinding | null {
@@ -325,18 +336,7 @@ export function isObjectLikeFactory(name: string): boolean {
     return [ 'object', 'strictObject', 'looseObject' ].includes(name);
 }
 
-const freezableSchemaFactoryNames = new Set([
-    'object',
-    'strictObject',
-    'looseObject',
-    'array',
-    'tuple',
-    'record',
-    'partialRecord',
-    'looseRecord'
-]);
-
-const valuePreservingWrapperNames = new Set([
+export const valuePreservingWrapperNames = new Set([
     'optional',
     'nullable',
     'nullish',
@@ -346,56 +346,6 @@ const valuePreservingWrapperNames = new Set([
     'catch',
     'readonly'
 ]);
-
-function isFreezableFactoryCall(bindings: ZodBindings, call: CallExpression): boolean {
-    const callName = getZodCallName(bindings, call);
-
-    return callName !== null && freezableSchemaFactoryNames.has(callName);
-}
-
-function underlyingSchemaExpression(bindings: ZodBindings, call: CallExpression): SchemaExpression | null {
-    const callName = getZodCallName(bindings, call);
-
-    if (callName !== null && valuePreservingWrapperNames.has(callName)) {
-        return firstExpressionArgument(call);
-    }
-
-    return babel.isMemberExpression(call.callee) && isExpressionNode(call.callee.object)
-        ? call.callee.object
-        : null;
-}
-
-export function producesFreezableValue(bindings: ZodBindings, expression: SchemaExpression): boolean {
-    let current: SchemaExpression | null = expression;
-
-    while (current !== null && babel.isCallExpression(current)) {
-        if (isFreezableFactoryCall(bindings, current)) {
-            return true;
-        }
-
-        current = underlyingSchemaExpression(bindings, current);
-    }
-
-    return false;
-}
-
-function isReadonlyApplication(bindings: ZodBindings, call: CallExpression): boolean {
-    return getZodCallName(bindings, call) === 'readonly' || getMemberName(call.callee) === 'readonly';
-}
-
-export function chainAppliesReadonly(bindings: ZodBindings, expression: SchemaExpression): boolean {
-    let current: SchemaExpression | null = expression;
-
-    while (current !== null && babel.isCallExpression(current)) {
-        if (isReadonlyApplication(bindings, current)) {
-            return true;
-        }
-
-        current = underlyingSchemaExpression(bindings, current);
-    }
-
-    return false;
-}
 
 function isReceiverOfMethodCall(path: MutationPath): boolean {
     const enclosingMember = path.parentPath?.node;
@@ -457,64 +407,4 @@ export function isStringTemplateLiteralPart(path: MutationPath, bindings: ZodBin
     return babel.isCallExpression(path.node) &&
         getZodCallName(bindings, path.node) === 'string' &&
         isElementOfTemplateLiteralParts(path, bindings);
-}
-
-const factoryNamesAcceptingUndefined = new Set([
-    'any',
-    'unknown',
-    'undefined',
-    'void',
-    'nullish',
-    'prefault',
-    'default',
-    '_default'
-]);
-const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null', 'nullish' ]);
-const acceptAnythingFactoryNames = new Set([ 'any', 'unknown' ]);
-
-const alreadyAcceptedValueByWrapper = new Map<string, ReadonlySet<string>>([
-    [ 'optional', factoryNamesAcceptingUndefined ],
-    [ 'nullable', factoryNamesAcceptingNull ]
-]);
-
-function outerSchemaName(bindings: ZodBindings, call: CallExpression): string {
-    return getZodCallName(bindings, call) ?? getMemberName(call.callee) ?? '';
-}
-
-function resolvesToAcceptAnything(bindings: ZodBindings, expression: SchemaExpression): boolean {
-    let current: SchemaExpression | null = expression;
-
-    while (current !== null && babel.isCallExpression(current)) {
-        const name = outerSchemaName(bindings, current);
-
-        if (acceptAnythingFactoryNames.has(name)) {
-            return true;
-        }
-
-        if (!valuePreservingWrapperNames.has(name)) {
-            return false;
-        }
-
-        current = underlyingSchemaExpression(bindings, current);
-    }
-
-    return false;
-}
-
-export function addingWrapperHasNoEffect(
-    bindings: ZodBindings,
-    expression: SchemaExpression,
-    wrapperName: string
-): boolean {
-    const acceptingFactories = alreadyAcceptedValueByWrapper.get(wrapperName);
-
-    if (acceptingFactories === undefined || !babel.isCallExpression(expression)) {
-        return false;
-    }
-
-    const outerName = outerSchemaName(bindings, expression);
-
-    return outerName === wrapperName ||
-        acceptingFactories.has(outerName) ||
-        resolvesToAcceptAnything(bindings, expression);
 }


### PR DESCRIPTION
Follow-up to #488, stacked on it (base retargets to `main` once #488 merges).

Generalises the "prove it unkillable before suppressing" rule to any operator whose equivalence check needs a schema's real shape when that schema is reached through a variable binding rather than written inline. When an operator hits a reference (e.g. `z.optional(user)` where `user` is a `const`), it now resolves the reference to its definition and continues the analysis there, so readonly, presence, and swap equivalences are judged on the resolved schema instead of bailing at the identifier.

Resolution follows aliases, object/array destructuring, member access into object literals, and imports (named, aliased, default, and string export names), recursing **across modules**. Cross-module specifiers are resolved with the TypeScript compiler API against the nearest discovered `tsconfig.json` (so `paths`/`baseUrl`/extension rewriting behave as in the project), then the file is read and parsed. Each resolved schema is interpreted with its own module's Zod bindings.

The rule is preserved by construction: resolution can only ever let us prove *more* mutants unkillable. Anything unresolved (missing file, unmatched path alias, non-schema, namespace import, unknown current file) is treated as unknown and the mutant is emitted, never suppressed. Only same-module analysis is complete; a schema imported and tested elsewhere is never assumed unkillable (forward "who imports this" is out of reach with plain Babel and intentionally not attempted).

The module loader is injected through a resolver env, so the resolver is covered both with an in-memory module map and with on-disk fixtures. Cross-module parsing needs `typescript` and `@babel/parser` at runtime, so both move from `devDependencies` to `dependencies`.
