### PR TITLE
Ignore type-only references when proving a presence wrapper masked

### DIFF
--- a/source/stryker-zod-mutator/masked-schema-references.ts
+++ b/source/stryker-zod-mutator/masked-schema-references.ts
@@ -106,6 +106,10 @@ function isPropertyOrMemberName(use: IdentifierUse): boolean {
     return babel.isMemberExpression(parent) && parent.property === node && !parent.computed;
 }
 
+function isTypeOnlyReference(use: IdentifierUse): boolean {
+    return babel.isTSTypeQuery(use.parent);
+}
+
 function isReference(use: IdentifierUse): boolean {
     return babel.isReferenced(use.node, use.parent, use.grandparent);
 }
@@ -165,7 +169,9 @@ export function presenceWrapperMaskedByEveryUse(
         return false;
     }
 
-    const uses = collectIdentifierUses(program, constId.name, []);
+    const uses = collectIdentifierUses(program, constId.name, []).filter(function (use) {
+        return !isTypeOnlyReference(use);
+    });
     const references = uses.filter(isReference);
     const hasForeignBinding = uses.some(function (use) {
         return isForeignBinding(use, constId);

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -333,6 +333,13 @@ test('does not add a presence wrapper masked by every use of a module const', fu
         ),
         []
     );
+    assert.deepStrictEqual(
+        collectMutations(
+            "import * as z from 'zod/mini'; const t = z.union([z.literal('w'), z.literal('b')]); type T = z.infer<typeof t>; export const s = z.nullable(t);",
+            'ZodNullableAdd'
+        ),
+        []
+    );
 });
 
 test('still mutates a const that is not masked by every use', function () {


### PR DESCRIPTION
A type-position reference to a schema `const` (`typeof s` inside `z.infer`/`z.output`, a type alias, or an annotation) cannot kill a runtime mutant, because Stryker runs the test suite against mutants rather than the type-checker. The masking analysis behind `ZodOptionalAdd`/`ZodNullableAdd` counted such references as distinguishing uses, which defeated the proof.

Concretely, a non-exported const used at runtime only through the same wrapper:

```ts
const correctionValuesSchema = z.readonly(z.object({ /* ... */ }));
type CorrectionValues = Readonly<z.output<typeof correctionValuesSchema>>;
// ...
correction: z.nullable(correctionValuesSchema)
```

was correctly proven masked without the `type` line, but the `typeof correctionValuesSchema` reference reintroduced the equivalent inner-`nullable` survivor. Type-only references are now excluded from the analysis.
