### PR TITLE
Skip `ZodReadonlyRemove` when an enclosing readonly re-freezes the value

### DIFF
--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -1531,3 +1531,58 @@ test('follows a string-literal export name across a module boundary', function (
 
     assert.ok(mutations.includes('z.optional(fields).readonly()'));
 });
+
+test('does not remove a readonly re-frozen by an enclosing readonly through a pipe', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const channelSchema = z.string(); export const s = z.readonly(z.pipe(z.string(), z.readonly(z.array(channelSchema))));",
+        'ZodReadonlyRemove'
+    );
+
+    assert.ok(!mutations.includes('z.array(channelSchema)'));
+});
+
+test('still removes a readonly that feeds a transform as pipe input', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; export const s = z.readonly(z.pipe(z.readonly(z.array(z.unknown())), z.transform(function (channels) { return channels; })));",
+        'ZodReadonlyRemove'
+    );
+
+    assert.ok(mutations.includes('z.array(z.unknown())'));
+});
+
+test('does not remove a readonly nested directly in another readonly', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; export const s = z.readonly(z.readonly(z.object({ a: z.string() })));",
+        'ZodReadonlyRemove'
+    );
+
+    assert.ok(!mutations.includes('z.object({\n  a: z.string()\n})'));
+});
+
+test('removes a readonly nested in a non-readonly wrapper', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; export const s = z.array(z.readonly(z.object({ a: z.string() })));",
+        'ZodReadonlyRemove'
+    );
+
+    assert.ok(mutations.includes('z.object({\n  a: z.string()\n})'));
+});
+
+test('handles a readonly-removal path without a parent', function () {
+    const mutator = createZodMutators([ 'ZodReadonlyRemove' ])[0];
+
+    if (mutator === undefined) {
+        assert.fail('Expected ZodReadonlyRemove to exist');
+    }
+
+    assert.deepStrictEqual(Array.from(mutator.mutate({ node: identifier('schema'), parentPath: null })), []);
+});
+
+test('detects an enclosing readonly through a classic pipe method call', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; export const s = z.readonly(z.string().pipe(z.readonly(z.array(z.string()))));",
+        'ZodReadonlyRemove'
+    );
+
+    assert.ok(!mutations.includes('z.array(z.string())'));
+});

--- a/source/stryker-zod-mutator/presence-mutations.ts
+++ b/source/stryker-zod-mutator/presence-mutations.ts
@@ -1,12 +1,13 @@
+import * as babel from '@babel/types';
 import type { Node as BabelNode } from '@babel/types';
 import {
     addWrapperOrMethod,
     removeMethodOrWrapper,
     replaceNullish
 } from './schema-call-mutations.ts';
-import { isExpressionNode, type MutationPath } from './ast.ts';
+import { getMemberName, isExpressionNode, type CallExpression, type MutationPath } from './ast.ts';
 import { createDefinition, type MutationDefinition } from './mutation-definition.ts';
-import { isSchemaValueChainRoot, type ZodBindings } from './zod-bindings.ts';
+import { getZodCallName, isSchemaValueChainRoot, type ZodBindings } from './zod-bindings.ts';
 import {
     addingWrapperHasNoEffect,
     chainAppliesReadonly,
@@ -35,7 +36,51 @@ function removeRedundantPresenceWrapper(
     });
 }
 
+type OutputRelation = 'none' | 'pipe' | 'readonly';
+
+function lastArgument(call: CallExpression): BabelNode | null {
+    return call.arguments.at(-1) ?? null;
+}
+
+function enclosingOutputRelation(child: BabelNode, parent: BabelNode, bindings: ZodBindings): OutputRelation {
+    if (!babel.isCallExpression(parent) || lastArgument(parent) !== child) {
+        return 'none';
+    }
+
+    const name = getZodCallName(bindings, parent) ?? getMemberName(parent.callee);
+
+    if (name === 'readonly') {
+        return 'readonly';
+    }
+
+    return name === 'pipe' ? 'pipe' : 'none';
+}
+
+function refrozenByEnclosingReadonly(path: MutationPath, bindings: ZodBindings): boolean {
+    let current = path;
+
+    for (;;) {
+        const parent = current.parentPath;
+
+        if (parent === null) {
+            return false;
+        }
+
+        const relation = enclosingOutputRelation(current.node, parent.node, bindings);
+
+        if (relation !== 'pipe') {
+            return relation === 'readonly';
+        }
+
+        current = parent;
+    }
+}
+
 function removeObservableReadonly(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
+    if (refrozenByEnclosingReadonly(path, bindings)) {
+        return [];
+    }
+
     return removeMethodOrWrapper(path, bindings, new Set([ 'readonly' ])).filter(function (inner) {
         return isExpressionNode(inner) && producesFreezableValue(bindings, inner);
     });

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -214,6 +214,11 @@ The guiding rule for every operator: emit a mutant unless it can be _proven_ unk
 module. A mutant we cannot prove equivalent is always emitted, even if it duplicates a wrapper already
 applied elsewhere. Suppressing a mutant that some test could kill is never acceptable.
 
+`ZodReadonlyRemove` applies the same rule to nested `readonly`s: when a `readonly`'s value flows unchanged
+to an enclosing `readonly` (directly, or as the output stage of a `z.pipe`), the outer one re-freezes the
+same value, so removing the inner one is unobservable and is skipped. A `readonly` on a pipe's input stage
+is not skipped, because a transform could observe or mutate the frozen value.
+
 `ZodOptionalAdd` and `ZodNullableAdd` apply this with a module-local check: when the mutated node is the
 whole value of, or a `union`/`discriminatedUnion` branch of, a **non-exported** `const`, and every
 reference to that `const` in the module already applies the same wrapper (e.g. `const t = z.union([...])`


### PR DESCRIPTION
A `z.readonly` whose produced value reaches an enclosing `z.readonly` unchanged is redundant, because the outer one re-freezes the same value. That happens when a readonly is nested directly in another readonly, or is the **output** stage of a `z.pipe` that is itself wrapped in readonly:

```ts
z.readonly(z.pipe(input, z.readonly(z.array(channelSchema))))
```

Removing the inner readonly here is unobservable, so it was a guaranteed survivor. It cannot be deleted at the source either: `@enormora/eslint-config-zod`'s `require-readonly-schema` only checks the immediate parent, so it mandates the inner wrapper regardless of the enclosing readonly. The mutator now stops generating the removal.

The check walks parent-ward through pipe output stages until it hits an enclosing readonly. A readonly on a pipe's **input** stage is intentionally still mutated: it feeds a transform that could observe or mutate the frozen value (a mutating transform throws on a frozen input), so its removal can be killable and suppressing it would risk a false 100%.

Also covers plain `z.readonly(z.readonly(x))` inner removal.
