### PR TITLE
Add `ZodReferencedSchemaWiden` to mutate schema references at use sites

### DIFF
--- a/source/stryker-zod-mutator/binding-resolution.ts
+++ b/source/stryker-zod-mutator/binding-resolution.ts
@@ -419,6 +419,12 @@ export function producesFreezableValue(bindings: ZodBindings, expression: Schema
     return Array.from(schemaChain(expression, bindings)).some(isFreezableFactoryCall);
 }
 
+export function resolvesToZodSchema(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    return Array.from(schemaChain(expression, bindings)).some(function (step) {
+        return getZodCallName(step.bindings, step.node) !== null;
+    });
+}
+
 function appliesReadonly(step: ChainStep): boolean {
     return getZodCallName(step.bindings, step.node) === 'readonly' || getMemberName(step.node.callee) === 'readonly';
 }

--- a/source/stryker-zod-mutator/mutation-catalog.ts
+++ b/source/stryker-zod-mutator/mutation-catalog.ts
@@ -1,0 +1,18 @@
+import { behaviorMutationDefinitions } from './behavior-mutations.ts';
+import { checkMutationDefinitions } from './check-mutations.ts';
+import { collectionMutationDefinitions } from './collection-mutations.ts';
+import type { MutationDefinition } from './mutation-definition.ts';
+import { objectMutationDefinitions } from './object-mutations.ts';
+import { presenceMutationDefinitions } from './presence-mutations.ts';
+import { primitiveMutationDefinitions } from './primitive-mutations.ts';
+import { referenceMutationDefinitions } from './reference-mutations.ts';
+
+export const mutationDefinitions: readonly MutationDefinition[] = [
+    ...primitiveMutationDefinitions,
+    ...presenceMutationDefinitions,
+    ...objectMutationDefinitions,
+    ...checkMutationDefinitions,
+    ...collectionMutationDefinitions,
+    ...behaviorMutationDefinitions,
+    ...referenceMutationDefinitions
+];

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -1593,3 +1593,120 @@ test('detects an enclosing readonly through a classic pipe method call', functio
 
     assert.ok(!mutations.includes('z.array(z.string())'));
 });
+
+test('widens a constraining schema reference in an object field', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.object({ f: foo });",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(mutations, [ 'z.unknown()' ]);
+});
+
+test('widens constraining schema references in union options and wrapper arguments', function () {
+    const unionMutations = collectMutations(
+        "import * as z from 'zod/mini'; const bar = z.string(); const baz = z.number(); export const s = z.union([bar, baz]);",
+        'ZodReferencedSchemaWiden'
+    );
+    const wrapperMutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.array(foo);",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(unionMutations, [ 'z.unknown()' ]);
+    assert.deepStrictEqual(wrapperMutations, [ 'z.unknown()' ]);
+});
+
+test('widens a referenced schema using the classic import style', function () {
+    const mutations = collectMutations(
+        "import { z } from 'zod/v4'; const foo = z.string(); export const s = z.object({ f: foo });",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(mutations, [ 'z.unknown()' ]);
+});
+
+test('does not widen a reference that already accepts anything', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.any(); export const s = z.object({ f: foo });",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('does not widen a reference that resolves to a non-schema', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = 'plain'; export const s = z.object({ f: foo });",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('does not widen an inline schema or a non-Zod object field', function () {
+    const inlineMutations = collectMutations(
+        "import * as z from 'zod/mini'; export const s = z.object({ f: z.string() });",
+        'ZodReferencedSchemaWiden'
+    );
+    const plainObjectMutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const opts = { f: foo };",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(inlineMutations, []);
+    assert.deepStrictEqual(plainObjectMutations, []);
+});
+
+test('widens a schema reference imported from another module', function () {
+    const widened = collectResolvedMutations(
+        "import * as z from 'zod/mini'; import { foo } from './foo'; export const s = z.object({ f: foo });",
+        'ZodReferencedSchemaWiden',
+        moduleResolverEnv({ './foo': "import * as z from 'zod/mini'; export const foo = z.string();" })
+    );
+    const permissive = collectResolvedMutations(
+        "import * as z from 'zod/mini'; import { foo } from './foo'; export const s = z.object({ f: foo });",
+        'ZodReferencedSchemaWiden',
+        moduleResolverEnv({ './foo': "import * as z from 'zod/mini'; export const foo = z.any();" })
+    );
+
+    assert.deepStrictEqual(widened, [ 'z.unknown()' ]);
+    assert.deepStrictEqual(permissive, []);
+});
+
+test('widens a reference using direct mini imports when unknown is importable', function () {
+    const mutations = collectMutations(
+        "import { object, string, unknown } from 'zod/mini'; const foo = string(); export const s = object({ f: foo });",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(mutations, [ 'unknown()' ]);
+});
+
+test('does not widen when the module cannot construct an unknown schema', function () {
+    const mutations = collectMutations(
+        "import { object, string } from 'zod/mini'; const foo = string(); export const s = object({ f: foo });",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('handles a widen path without a parent', function () {
+    const mutator = createZodMutators([ 'ZodReferencedSchemaWiden' ])[0];
+
+    if (mutator === undefined) {
+        assert.fail('Expected ZodReferencedSchemaWiden to exist');
+    }
+
+    assert.deepStrictEqual(Array.from(mutator.mutate({ node: identifier('schema'), parentPath: null })), []);
+});
+
+test('does not widen a reference inside a non-Zod call object', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = notZod({ f: foo });",
+        'ZodReferencedSchemaWiden'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});

--- a/source/stryker-zod-mutator/mutations.ts
+++ b/source/stryker-zod-mutator/mutations.ts
@@ -1,26 +1,8 @@
-import { behaviorMutationDefinitions } from './behavior-mutations.ts';
-import { checkMutationDefinitions } from './check-mutations.ts';
-import { collectionMutationDefinitions } from './collection-mutations.ts';
-import {
-    createZodMutator,
-    type MutationDefinition,
-    type ZodMutator
-} from './mutation-definition.ts';
-import { objectMutationDefinitions } from './object-mutations.ts';
+import { createZodMutator, type ZodMutator } from './mutation-definition.ts';
+import { mutationDefinitions } from './mutation-catalog.ts';
 import type { ZodMutationOperator } from './operator.ts';
-import { presenceMutationDefinitions } from './presence-mutations.ts';
-import { primitiveMutationDefinitions } from './primitive-mutations.ts';
 import type { ResolverEnv } from './binding-resolution.ts';
 import { filesystemResolverEnv } from './filesystem-module-loader.ts';
-
-const mutationDefinitions: readonly MutationDefinition[] = [
-    ...primitiveMutationDefinitions,
-    ...presenceMutationDefinitions,
-    ...objectMutationDefinitions,
-    ...checkMutationDefinitions,
-    ...collectionMutationDefinitions,
-    ...behaviorMutationDefinitions
-];
 
 export function createZodMutatorsWithResolver(
     operators: readonly ZodMutationOperator[],

--- a/source/stryker-zod-mutator/operator.ts
+++ b/source/stryker-zod-mutator/operator.ts
@@ -8,7 +8,8 @@ export const zodMutationCategories = [
     'collection',
     'union',
     'fallback',
-    'coercion'
+    'coercion',
+    'reference'
 ] as const;
 
 export type ZodMutationCategory = typeof zodMutationCategories[number];
@@ -51,7 +52,8 @@ export const zodMutationOperators = [
     'ZodNumericLiteralChange',
     'ZodFallbackRemove',
     'ZodCustomBehaviorRemove',
-    'ZodCoercionRemove'
+    'ZodCoercionRemove',
+    'ZodReferencedSchemaWiden'
 ] as const;
 
 export type ZodMutationOperator = typeof zodMutationOperators[number];
@@ -94,5 +96,6 @@ export const zodMutationOperatorCategories: Record<ZodMutationOperator, ZodMutat
     ZodNumericLiteralChange: 'union',
     ZodFallbackRemove: 'fallback',
     ZodCustomBehaviorRemove: 'fallback',
-    ZodCoercionRemove: 'coercion'
+    ZodCoercionRemove: 'coercion',
+    ZodReferencedSchemaWiden: 'reference'
 };

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -40,7 +40,8 @@ Use `await` in the config file. Stryker’s mutator registry is ESM-only and not
         'collection',
         'union',
         'fallback',
-        'coercion'
+        'coercion',
+        'reference'
     ],
     includedOperators: [
         'ZodPrimitiveFactorySwap',
@@ -80,7 +81,8 @@ Use `await` in the config file. Stryker’s mutator registry is ESM-only and not
         'ZodNumericLiteralChange',
         'ZodFallbackRemove',
         'ZodCustomBehaviorRemove',
-        'ZodCoercionRemove'
+        'ZodCoercionRemove',
+        'ZodReferencedSchemaWiden'
     ]
 }
 ```
@@ -101,7 +103,7 @@ export default await withZodMutators({
 ```
 
 Available categories are `primitive`, `presence`, `readonly`, `object`, `string`, `number`, `collection`,
-`union`, `fallback`, and `coercion`.
+`union`, `fallback`, `coercion`, and `reference`.
 
 ## Supported Zod Imports
 
@@ -159,6 +161,7 @@ The default set enables every operator below.
 | `ZodFallbackRemove`           | `z.string().default('x')`                    | `z.string()`                              |
 | `ZodCustomBehaviorRemove`     | `z.string().transform(String)`               | `z.string()`                              |
 | `ZodCoercionRemove`           | `z.coerce.number()`                          | `z.number()`                              |
+| `ZodReferencedSchemaWiden`    | `z.object({ f: fooSchema })`                 | `z.object({ f: z.unknown() })`            |
 
 `ZodPrimitiveFactorySwap` swaps zero-argument calls among `z.string()`, `z.number()`, `z.bigint()`,
 `z.boolean()`, `z.date()`, `z.symbol()`, `z.null()`, `z.undefined()`, `z.void()`, `z.never()`, `z.any()`,
@@ -244,3 +247,18 @@ be resolved (a missing file, a `paths` alias with no matching config, a referenc
 a schema, or a namespace import) is treated as unknown and the mutant is emitted rather than suppressed.
 Only same-module (`export`) analysis is complete; a schema imported elsewhere and tested there is never
 assumed unkillable.
+
+## Widening referenced schemas
+
+A field, wrapper argument, or union option whose value is a schema written inline (`f: z.string()`) is
+already mutated in place by the type and check operators. When that value is instead a reference to a schema
+defined elsewhere (`f: fooSchema`), those operators fire only at the definition, so nothing at the use site
+forces a test that the field actually validates its input. `ZodReferencedSchemaWiden` closes that gap: it
+replaces such a reference with `z.unknown()`, which a test kills by feeding a value the referenced schema
+rejects.
+
+To stay faithful to the guiding rule, it uses binding resolution and emits the mutant only when the
+reference resolves to a schema that does not already accept everything, so the widened mutant is always
+distinguishable from the original. It intentionally does not re-assert the referenced schema's internal
+constraints at each use site; that stays the dedicated schema's own tests' responsibility. Disable the
+`reference` category or the operator to opt out.

--- a/source/stryker-zod-mutator/reference-mutations.ts
+++ b/source/stryker-zod-mutator/reference-mutations.ts
@@ -1,0 +1,102 @@
+import * as babel from '@babel/types';
+import type { Node as BabelNode } from '@babel/types';
+import type { MutationPath, SchemaExpression } from './ast.ts';
+import { createDefinition, type MutationDefinition } from './mutation-definition.ts';
+import {
+    buildZodCall,
+    getZodCallName,
+    isObjectLikeFactory,
+    type ZodApiStyle,
+    type ZodBindings
+} from './zod-bindings.ts';
+import { resolvesToAcceptAnything, resolvesToZodSchema } from './binding-resolution.ts';
+
+function moduleStyle(bindings: ZodBindings): ZodApiStyle {
+    return bindings.namespaces[0]?.style ?? bindings.directBindings[0]?.style ?? 'classic';
+}
+
+const ancestorDepth = { property: 1, optionsCall: 2, objectFactory: 3 };
+
+function ancestorNode(path: MutationPath, depth: number): BabelNode | null {
+    let current: MutationPath | null = path;
+    let remaining = depth;
+
+    while (current !== null && remaining > 0) {
+        current = current.parentPath;
+        remaining -= 1;
+    }
+
+    return current?.node ?? null;
+}
+
+function isZodObjectFactory(node: Readonly<BabelNode> | null, bindings: ZodBindings): boolean {
+    return babel.isCallExpression(node) && isObjectLikeFactory(getZodCallName(bindings, node) ?? '');
+}
+
+function isZodCall(node: Readonly<BabelNode> | null, bindings: ZodBindings): boolean {
+    return babel.isCallExpression(node) && getZodCallName(bindings, node) !== null;
+}
+
+function isZodObjectFieldValue(
+    reference: Readonly<babel.Identifier>,
+    path: MutationPath,
+    bindings: ZodBindings
+): boolean {
+    const property = ancestorNode(path, ancestorDepth.property);
+    const holdsReference = babel.isObjectProperty(property) && !property.computed && property.value === reference;
+
+    return holdsReference && isZodObjectFactory(ancestorNode(path, ancestorDepth.objectFactory), bindings);
+}
+
+function isZodCallArgument(reference: Readonly<babel.Identifier>, path: MutationPath, bindings: ZodBindings): boolean {
+    const call = ancestorNode(path, ancestorDepth.property);
+
+    return babel.isCallExpression(call) && call.arguments.includes(reference) && isZodCall(call, bindings);
+}
+
+function isZodOptionsElement(
+    reference: Readonly<babel.Identifier>,
+    path: MutationPath,
+    bindings: ZodBindings
+): boolean {
+    const options = ancestorNode(path, ancestorDepth.property);
+    const isElement = babel.isArrayExpression(options) && options.elements.includes(reference);
+    const call = ancestorNode(path, ancestorDepth.optionsCall);
+
+    return isElement && babel.isArrayExpression(options) && isZodCall(call, bindings) &&
+        babel.isCallExpression(call) && call.arguments.includes(options);
+}
+
+function isSchemaReferenceSlot(
+    reference: Readonly<babel.Identifier>,
+    path: MutationPath,
+    bindings: ZodBindings
+): boolean {
+    return isZodObjectFieldValue(reference, path, bindings) ||
+        isZodCallArgument(reference, path, bindings) ||
+        isZodOptionsElement(reference, path, bindings);
+}
+
+function widensToDistinguishableSchema(reference: SchemaExpression, bindings: ZodBindings): boolean {
+    return resolvesToZodSchema(bindings, reference) && !resolvesToAcceptAnything(bindings, reference);
+}
+
+function widenReferencedSchema(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
+    const reference = path.node;
+
+    if (!babel.isIdentifier(reference) || !isSchemaReferenceSlot(reference, path, bindings)) {
+        return [];
+    }
+
+    if (!widensToDistinguishableSchema(reference, bindings)) {
+        return [];
+    }
+
+    const widened = buildZodCall(bindings, moduleStyle(bindings), 'unknown', []);
+
+    return widened === null ? [] : [ widened ];
+}
+
+export const referenceMutationDefinitions: readonly MutationDefinition[] = [
+    createDefinition('ZodReferencedSchemaWiden', widenReferencedSchema)
+];


### PR DESCRIPTION
Closes the use-site blind spot for schema references. A field, wrapper argument, or union option written inline (`f: z.string()`) is already mutated by the type/check operators, but when the value is a reference to a schema defined elsewhere (`f: fooSchema`) those operators fire only at the definition. Nothing at the use site then forces a test that the field validates its input, so a regression loosening `f: fooSchema` to an unvalidated schema passes a green mutation gate.

`ZodReferencedSchemaWiden` replaces such a reference with `z.unknown()` in object fields, `z.union`/`z.discriminatedUnion` options, and Zod call arguments (`z.array(foo)`, `z.optional(foo)`). Killing it requires a use-site test that feeds a value the referenced schema rejects.

It stays faithful to the "emit only when provably killable" rule by using the cross-module binding resolver: the mutant is emitted only when the reference resolves to a Zod schema that does **not** already accept everything, so the widened form is always distinguishable from the original and never an equivalent survivor. Unresolvable references, references to `any`/`unknown`, non-schema values, and inline schemas are skipped.

By design it does not re-assert the referenced schema's internal constraints at each use site (that stays the dedicated schema's own tests' responsibility); it forces the one-failure-path contract that the field validates *something*. New `reference` category, default on, opt-out via `includedOperators`/`includedCategories`.

Follow-up (separate PR): extend presence add/remove to reference-valued fields (`f: fooSchema` optional/nullable add, `f: fooSchema.optional()` removal).
