### PR TITLE
Apply object field presence mutators to schema references

### DIFF
--- a/source/stryker-zod-mutator/binding-resolution.ts
+++ b/source/stryker-zod-mutator/binding-resolution.ts
@@ -5,6 +5,7 @@ import {
     buildZodBindings,
     firstExpressionArgument,
     getZodCallName,
+    isZodSchemaExpression,
     valuePreservingWrapperNames,
     type ZodBindings
 } from './zod-bindings.ts';
@@ -423,6 +424,10 @@ export function resolvesToZodSchema(bindings: ZodBindings, expression: SchemaExp
     return Array.from(schemaChain(expression, bindings)).some(function (step) {
         return getZodCallName(step.bindings, step.node) !== null;
     });
+}
+
+export function isZodSchemaOrReference(bindings: ZodBindings, expression: SchemaExpression): boolean {
+    return isZodSchemaExpression(bindings, expression) || resolvesToZodSchema(bindings, expression);
 }
 
 function appliesReadonly(step: ChainStep): boolean {

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -1715,3 +1715,70 @@ test('does not widen a reference inside a non-Zod call object', function () {
 
     assert.deepStrictEqual(mutations, []);
 });
+
+test('adds a presence wrapper to a reference-valued object field', function () {
+    const optional = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.object({ f: foo });",
+        'ZodObjectFieldOptionalAdd'
+    );
+    const nullable = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.object({ f: foo });",
+        'ZodObjectFieldNullableAdd'
+    );
+    const classic = collectMutations(
+        "import { z } from 'zod/v4'; const foo = z.string(); export const s = z.object({ f: foo });",
+        'ZodObjectFieldOptionalAdd'
+    );
+
+    assert.deepStrictEqual(optional, [ 'z.object({\n  f: z.optional(foo)\n})' ]);
+    assert.deepStrictEqual(nullable, [ 'z.object({\n  f: z.nullable(foo)\n})' ]);
+    assert.deepStrictEqual(classic, [ 'z.object({\n  f: foo.optional()\n})' ]);
+});
+
+test('does not add a presence wrapper to a reference that already accepts the value', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.any(); export const s = z.object({ f: foo });",
+        'ZodObjectFieldOptionalAdd'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('removes a presence wrapper applied to a reference-valued field', function () {
+    const methodForm = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.object({ f: foo.optional() });",
+        'ZodOptionalRemove'
+    );
+    const wrapperForm = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.object({ f: z.nullable(foo) });",
+        'ZodNullableRemove'
+    );
+
+    assert.deepStrictEqual(methodForm, [ 'foo' ]);
+    assert.deepStrictEqual(wrapperForm, [ 'foo' ]);
+});
+
+test('does not remove a presence wrapper that a reference makes redundant', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.any(); export const s = z.object({ f: foo.optional() });",
+        'ZodOptionalRemove'
+    );
+
+    assert.deepStrictEqual(mutations, []);
+});
+
+test('adds and removes presence wrappers on schema references imported from another module', function () {
+    const added = collectResolvedMutations(
+        "import * as z from 'zod/mini'; import { foo } from './foo'; export const s = z.object({ f: foo });",
+        'ZodObjectFieldOptionalAdd',
+        moduleResolverEnv({ './foo': "import * as z from 'zod/mini'; export const foo = z.string();" })
+    );
+    const removed = collectResolvedMutations(
+        "import * as z from 'zod/mini'; import { foo } from './foo'; export const s = z.object({ f: foo.optional() });",
+        'ZodOptionalRemove',
+        moduleResolverEnv({ './foo': "import * as z from 'zod/mini'; export const foo = z.string();" })
+    );
+
+    assert.ok(added.includes('z.object({\n  f: z.optional(foo)\n})'));
+    assert.ok(removed.includes('foo'));
+});

--- a/source/stryker-zod-mutator/object-mutations.ts
+++ b/source/stryker-zod-mutator/object-mutations.ts
@@ -16,12 +16,12 @@ import {
     expressionStyle,
     getZodCallName,
     isObjectLikeFactory,
-    isZodSchemaExpression,
+    moduleStyle,
     replaceZodCallee,
     type ZodApiStyle,
     type ZodBindings
 } from './zod-bindings.ts';
-import { addingWrapperHasNoEffect } from './binding-resolution.ts';
+import { addingWrapperHasNoEffect, isZodSchemaOrReference } from './binding-resolution.ts';
 import { removeMethodOrWrapper } from './schema-call-mutations.ts';
 
 function mutateObjectFactory(path: MutationPath, bindings: ZodBindings): readonly BabelNode[] {
@@ -105,13 +105,12 @@ function fieldWrapTarget(
     index: number
 ): FieldWrapTarget | null {
     const value = objectFieldValue(objectExpression, index);
-    const style = value === null ? null : expressionStyle(bindings, value);
 
-    if (value === null || style === null || !isZodSchemaExpression(bindings, value)) {
+    if (value === null || !isZodSchemaOrReference(bindings, value)) {
         return null;
     }
 
-    return { value, style };
+    return { value, style: expressionStyle(bindings, value) ?? moduleStyle(bindings) };
 }
 
 function wrapObjectField(

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -262,3 +262,9 @@ reference resolves to a schema that does not already accept everything, so the w
 distinguishable from the original. It intentionally does not re-assert the referenced schema's internal
 constraints at each use site; that stays the dedicated schema's own tests' responsibility. Disable the
 `reference` category or the operator to opt out.
+
+The object field presence operators use the same resolution to reach references. `ZodObjectFieldOptionalAdd`
+and `ZodObjectFieldNullableAdd` wrap a reference-valued field (`f: fooSchema` becomes `f: z.optional(fooSchema)`),
+and `ZodOptionalRemove`/`ZodNullableRemove` unwrap one applied to a reference (`f: fooSchema.optional()` becomes
+`f: fooSchema`). Both skip the mutant when the resolved reference already accepts the added or removed value,
+so no equivalent mutant is produced.

--- a/source/stryker-zod-mutator/reference-mutations.ts
+++ b/source/stryker-zod-mutator/reference-mutations.ts
@@ -6,14 +6,10 @@ import {
     buildZodCall,
     getZodCallName,
     isObjectLikeFactory,
-    type ZodApiStyle,
+    moduleStyle,
     type ZodBindings
 } from './zod-bindings.ts';
 import { resolvesToAcceptAnything, resolvesToZodSchema } from './binding-resolution.ts';
-
-function moduleStyle(bindings: ZodBindings): ZodApiStyle {
-    return bindings.namespaces[0]?.style ?? bindings.directBindings[0]?.style ?? 'classic';
-}
 
 const ancestorDepth = { property: 1, optionsCall: 2, objectFactory: 3 };
 

--- a/source/stryker-zod-mutator/schema-call-mutations.ts
+++ b/source/stryker-zod-mutator/schema-call-mutations.ts
@@ -23,7 +23,7 @@ import {
     type ZodApiStyle,
     type ZodBindings
 } from './zod-bindings.ts';
-import { addingWrapperHasNoEffect } from './binding-resolution.ts';
+import { addingWrapperHasNoEffect, isZodSchemaOrReference } from './binding-resolution.ts';
 
 export function removeMethod(
     call: CallExpression,
@@ -41,7 +41,7 @@ export function removeMethod(
         return [];
     }
 
-    return isZodSchemaExpression(bindings, object) ? [ cloneExpression(object) ] : [];
+    return isZodSchemaOrReference(bindings, object) ? [ cloneExpression(object) ] : [];
 }
 
 function removeWrapper(
@@ -56,7 +56,7 @@ function removeWrapper(
         return [];
     }
 
-    return isZodSchemaExpression(bindings, schema) ? [ cloneExpression(schema) ] : [];
+    return isZodSchemaOrReference(bindings, schema) ? [ cloneExpression(schema) ] : [];
 }
 
 export function removeMethodOrWrapper(

--- a/source/stryker-zod-mutator/zod-bindings.ts
+++ b/source/stryker-zod-mutator/zod-bindings.ts
@@ -284,6 +284,10 @@ export function expressionStyle(bindings: ZodBindings, expression: SchemaExpress
     }
 }
 
+export function moduleStyle(bindings: ZodBindings): ZodApiStyle {
+    return bindings.namespaces[0]?.style ?? bindings.directBindings[0]?.style ?? 'classic';
+}
+
 export function buildZodCall(
     bindings: ZodBindings,
     style: ZodApiStyle,


### PR DESCRIPTION
Follow-up to #503. Extends the object field presence operators to reference-valued fields, using the same binding resolver.

Until now `ZodObjectFieldOptionalAdd`/`ZodObjectFieldNullableAdd` and the `ZodOptionalRemove`/`ZodNullableRemove` family only recognised inline schema expressions, so a field whose value is a reference to a schema defined elsewhere got no presence mutant at all:

- `f: fooSchema` was never wrapped (no "field is required" / "field rejects null" signal at the use site),
- `f: fooSchema.optional()` never had its `.optional()` removed.

Now the field-wrap and wrapper-removal recognition accept a reference that resolves (cross-module) to a Zod schema, building the wrapper in the current module's import style (`z.optional(fooSchema)` for mini, `fooSchema.optional()` for classic). Both paths remain gated by the resolution-aware `addingWrapperHasNoEffect`, so a wrapper is neither added to nor removed from a reference that already accepts the value (e.g. `foo` resolving to `z.any()`), keeping every emitted mutant killable and never an equivalent survivor. Inline behaviour is unchanged.

`moduleStyle` moves to `zod-bindings` (shared with the widen operator), and a new `isZodSchemaOrReference` predicate in `binding-resolution` backs the recognition.
