### PR TITLE
Skip presence-wrapper adds redundant through a value-preserving chain

### DIFF
--- a/source/stryker-zod-mutator/binding-resolution.ts
+++ b/source/stryker-zod-mutator/binding-resolution.ts
@@ -438,57 +438,89 @@ export function chainAppliesReadonly(bindings: ZodBindings, expression: SchemaEx
     return Array.from(schemaChain(expression, bindings)).some(appliesReadonly);
 }
 
-const acceptAnythingFactoryNames = new Set([ 'any', 'unknown' ]);
-
 function schemaName(step: ChainStep): string {
     return getZodCallName(step.bindings, step.node) ?? getMemberName(step.node.callee) ?? '';
 }
 
-function isBreakingWrapper(step: ChainStep): boolean {
-    return !valuePreservingWrapperNames.has(schemaName(step));
+// A wrapper that re-restricts presence: `nonoptional` passes `null` through unchanged but rejects
+// `undefined`, so it is transparent when reasoning about `null` yet breaks reasoning about `undefined`.
+const presenceRestrictingWrappers = new Set([ 'nonoptional' ]);
+
+const acceptAnythingPreservingWrappers = new Set(
+    Array.from(valuePreservingWrapperNames).filter(function (name) {
+        return !presenceRestrictingWrappers.has(name);
+    })
+);
+
+type PresenceAcceptance = {
+    readonly alreadyAccepting: ReadonlySet<string>;
+    readonly transparent: ReadonlySet<string>;
+};
+
+const presenceAcceptanceByWrapper = new Map<string, PresenceAcceptance>([
+    [
+        'nullable',
+        {
+            alreadyAccepting: new Set([ 'nullable', 'nullish', 'null', 'any', 'unknown' ]),
+            transparent: valuePreservingWrapperNames
+        }
+    ],
+    [
+        'optional',
+        {
+            alreadyAccepting: new Set([
+                'optional',
+                'nullish',
+                'undefined',
+                'void',
+                'default',
+                '_default',
+                'prefault',
+                'any',
+                'unknown'
+            ]),
+            transparent: acceptAnythingPreservingWrappers
+        }
+    ]
+]);
+
+function chainAcceptsBefore(
+    bindings: ZodBindings,
+    expression: SchemaExpression,
+    alreadyAccepting: ReadonlySet<string>,
+    transparent: ReadonlySet<string>
+): boolean {
+    for (const step of schemaChain(expression, bindings)) {
+        const name = schemaName(step);
+
+        if (alreadyAccepting.has(name)) {
+            return true;
+        }
+
+        if (!transparent.has(name)) {
+            return false;
+        }
+    }
+
+    return false;
 }
 
 export function resolvesToAcceptAnything(bindings: ZodBindings, expression: SchemaExpression): boolean {
-    const steps = Array.from(schemaChain(expression, bindings));
-    const decisive = steps.find(function (step) {
-        return acceptAnythingFactoryNames.has(schemaName(step)) || isBreakingWrapper(step);
-    });
-
-    return decisive !== undefined && acceptAnythingFactoryNames.has(schemaName(decisive));
+    return chainAcceptsBefore(
+        bindings,
+        expression,
+        new Set([ 'any', 'unknown' ]),
+        acceptAnythingPreservingWrappers
+    );
 }
-
-const factoryNamesAcceptingUndefined = new Set([
-    'any',
-    'unknown',
-    'undefined',
-    'void',
-    'nullish',
-    'prefault',
-    'default',
-    '_default'
-]);
-const factoryNamesAcceptingNull = new Set([ 'any', 'unknown', 'null', 'nullish' ]);
-
-const alreadyAcceptedValueByWrapper = new Map<string, ReadonlySet<string>>([
-    [ 'optional', factoryNamesAcceptingUndefined ],
-    [ 'nullable', factoryNamesAcceptingNull ]
-]);
 
 export function addingWrapperHasNoEffect(
     bindings: ZodBindings,
     expression: SchemaExpression,
     wrapperName: string
 ): boolean {
-    const acceptingFactories = alreadyAcceptedValueByWrapper.get(wrapperName);
-    const [ outer ] = Array.from(schemaChain(expression, bindings));
+    const acceptance = presenceAcceptanceByWrapper.get(wrapperName);
 
-    if (acceptingFactories === undefined || outer === undefined) {
-        return false;
-    }
-
-    const outerName = schemaName(outer);
-
-    return outerName === wrapperName ||
-        acceptingFactories.has(outerName) ||
-        resolvesToAcceptAnything(bindings, expression);
+    return acceptance !== undefined &&
+        chainAcceptsBefore(bindings, expression, acceptance.alreadyAccepting, acceptance.transparent);
 }

--- a/source/stryker-zod-mutator/mutations.test.ts
+++ b/source/stryker-zod-mutator/mutations.test.ts
@@ -1782,3 +1782,65 @@ test('adds and removes presence wrappers on schema references imported from anot
     assert.ok(added.includes('z.object({\n  f: z.optional(foo)\n})'));
     assert.ok(removed.includes('foo'));
 });
+
+test('does not add nullable when an inner nullable is reached through presence wrappers', function () {
+    const optNull = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.optional(z.nullable(foo));",
+        'ZodNullableAdd'
+    );
+    const field = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.object({ f: z.optional(z.nullable(foo)) });",
+        'ZodObjectFieldNullableAdd'
+    );
+
+    assert.deepStrictEqual(optNull, []);
+    assert.deepStrictEqual(field, []);
+});
+
+test('does not add optional when an inner optional is reached through presence wrappers', function () {
+    const nullOpt = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.nullable(z.optional(foo));",
+        'ZodOptionalAdd'
+    );
+
+    assert.deepStrictEqual(nullOpt, []);
+});
+
+test('sees through a resolved reference when skipping a redundant presence wrapper', function () {
+    const nullableAdd = collectResolvedMutations(
+        "import * as z from 'zod/mini'; import { foo } from './foo'; export const s = z.optional(z.nullable(foo));",
+        'ZodNullableAdd',
+        moduleResolverEnv({ './foo': "import * as z from 'zod/mini'; export const foo = z.string();" })
+    );
+
+    assert.deepStrictEqual(nullableAdd, []);
+});
+
+test('still adds a presence wrapper when a transform can observe the added value', function () {
+    const mutations = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.optional(z.pipe(z.nullable(foo), z.transform(function (v) { return v; })));",
+        'ZodNullableAdd'
+    );
+
+    assert.ok(mutations.some(function (mutation) {
+        return mutation.startsWith('z.nullable(');
+    }));
+});
+
+test('still adds optional across a nonoptional that re-rejects undefined', function () {
+    const throughNonoptional = collectMutations(
+        "import * as z from 'zod/mini'; const foo = z.string(); export const s = z.nonoptional(z.optional(foo));",
+        'ZodOptionalAdd'
+    );
+    const nonoptionalAny = collectMutations(
+        "import * as z from 'zod/mini'; export const s = z.nonoptional(z.any());",
+        'ZodOptionalAdd'
+    );
+
+    assert.ok(throughNonoptional.some(function (mutation) {
+        return mutation.startsWith('z.optional(z.nonoptional(');
+    }));
+    assert.ok(nonoptionalAny.some(function (mutation) {
+        return mutation.startsWith('z.optional(z.nonoptional(');
+    }));
+});

--- a/source/stryker-zod-mutator/readme.md
+++ b/source/stryker-zod-mutator/readme.md
@@ -188,9 +188,13 @@ mutation is emitted. Raising it (e.g. `min(0)` to `min(1)`) is still emitted, an
 `z.unknown()`, `z.undefined()`, `z.void()`, `z.nullish()`, a `default`/`prefault` schema, and anything
 already `optional`), and `ZodNullableAdd` and `ZodObjectFieldNullableAdd` skip schemas that already accept
 `null` (`z.any()`, `z.unknown()`, `z.null()`, `z.nullish()`, and anything already `nullable`), because
-wrapping them changes nothing at runtime. Both also see through `optional`/`nullable` (and other
-value-preserving wrappers) to an `z.any()`/`z.unknown()` leaf, so e.g. `z.nullable(z.optional(z.unknown()))`
-is not emitted. `ZodOptionalRemove` and `ZodNullableRemove` likewise skip removals whose remaining
+wrapping them changes nothing at runtime. Both walk outward through the value-preserving wrapper chain
+looking for a step that already admits the value, so a redundant wrapper is skipped even when it sits
+under other wrappers, e.g. `z.optional(z.nullable(X))` gets no `nullable` add and `z.nullable(z.optional(X))`
+gets no `optional` add. The walk stops at anything that could make the added wrapper observable: a
+value-transforming step (`transform`, `pipe`) stops both, and `nonoptional` stops the `optional` walk
+because it re-rejects `undefined`, so `z.nonoptional(z.optional(X))` still gets an `optional` add (it is
+killable). `ZodOptionalRemove` and `ZodNullableRemove` likewise skip removals whose remaining
 schema still admits the value (e.g. removing `.optional()` from `z.unknown().optional()`). `ZodOptionalAdd`
 and `ZodNullableAdd` also wrap only at the root of a schema value chain, so `z.string().min(2)` yields
 `z.string().min(2).optional()` rather than the invalid `z.string().optional().min(2)`. They also skip a


### PR DESCRIPTION
Fixes the reported equivalent `nullable`/`optional` adds on nested presence wrappers, which blocked a `break = 100` gate. For any `z.optional(z.nullable(X))` the mutator emitted `ZodNullableAdd` and `ZodObjectFieldNullableAdd` even though the schema already accepts `null`, and symmetrically for `z.nullable(z.optional(X))` and `ZodOptionalAdd`. Verified equivalent against `zod/mini` across all input classes.

`addingWrapperHasNoEffect` previously inspected only the outermost wrapper. It now walks outward through the value-preserving wrapper chain and skips the add when a step already admits the value. The walk stops at anything that could make the added wrapper observable, so it stays sound:

- `transform`/`pipe` stop both directions (a transform can turn the short-circuited `null`/`undefined` into something else, which a test can observe).
- `nonoptional` stops the `optional` walk, because it re-rejects `undefined`; `z.nonoptional(z.optional(X))` therefore still gets an `optional` add (it is killable).
- `catch`/`readonly`/`default` are transparent (confirmed equivalent empirically).

It also fixes a latent unsoundness found while verifying this: `resolvesToAcceptAnything` walked through `nonoptional` to an `any`/`unknown` leaf and reported `z.nonoptional(z.any())` as accepting everything, so its (killable) `ZodOptionalAdd` was being suppressed. The accept-anything walk now stops at `nonoptional` too, which additionally lets `ZodReferencedSchemaWiden` widen such a reference.
